### PR TITLE
Fix the compilation issue on an ARM-based PC

### DIFF
--- a/coredump/arm/arm64.h
+++ b/coredump/arm/arm64.h
@@ -54,12 +54,14 @@ struct user_pac_mask {
     uint64_t insn_mask;
 };
 
+#ifdef __x86_64__
 struct elf_siginfo {
     int si_signo;
     int si_errno;
     int si_code;
     // char padding[36];
 };
+#endif
 
 struct __kernel_old_timeval {
     long tv_sec;

--- a/coredump/core.h
+++ b/coredump/core.h
@@ -60,6 +60,7 @@ typedef unsigned long long __ull[2];
 # +--------------------------------+
 */
 
+#ifdef __x86_64__
 struct elf_prpsinfo {
     char pr_state;
     char pr_sname;
@@ -75,6 +76,7 @@ struct elf_prpsinfo {
     char pr_fname[16];
     char pr_psargs[80];
 };
+#endif
 
 struct vma {
     ulong addr;


### PR DESCRIPTION
1. /usr/include/aarch64-linux-gnu/sys/procfs.h:49:8: note: previous definition of ‘struct elf_siginfo’
2. /usr/include/aarch64-linux-gnu/sys/procfs.h:84:8: note: previous definition of ‘struct elf_prpsinfo’