### PR TITLE
Add the new feature

### DIFF
--- a/procrank/procrank.h
+++ b/procrank/procrank.h
@@ -36,6 +36,7 @@ public:
     void init_command();
     void cmd_main(void) override;
     void parser_process_memory();
+    void parser_process_name();
     std::shared_ptr<procrank> parser_vma(ulong& vma_addr, ulong& task_addr);
     DEFINE_PLUGIN_INSTANCE(Procrank)
 

--- a/property/prop.cpp
+++ b/property/prop.cpp
@@ -51,19 +51,10 @@ void Prop::cmd_main(void) {
             case 'a':
             {
                 if (prop_map.size() == 0){
-                    field_init(prop_info,name);
-                    if (field_offset(prop_info,name) == -1){
-                        fprintf(fp, "Not load libc.so symbol, Please run getprop -s <symbol path> load it !\n");
-                        return;
-                    }
-                    if (parser_propertys()){
-                        print_propertys();
-                    }else{
-                        fprintf(fp, "Can't get property from dump \n");
-                    }
-                }else{
-                    print_propertys();
+                    parser_propertys();
+                    parser_prop_by_init();
                 }
+                print_propertys();
             }
             break;
             case 'p':

--- a/property/propinfo.h
+++ b/property/propinfo.h
@@ -97,6 +97,9 @@ public:
     bool parser_prop_area(size_t vaddr);
     void parser_prop_bt(size_t root, size_t prop_bt_addr);
     void parser_prop_info(size_t prop_info_addr);
+    void parser_prop_by_init();
+    bool for_each_prop(uint32_t prop_bt_off, size_t vma_len, char *vma_data);
+    std::optional<std::string> cleanString(const std::string &str);
     void cmd_main(void) override;
     std::string get_prop(std::string name);
 };


### PR DESCRIPTION
1. For prop, since the linked list is often lost, we traverse the VMA to find all props
2. The comm name in task_struct cannot distinguish specific processes, so we add cmdline to confirm.