### PR TITLE
Optimize plugin loading speed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,7 +406,7 @@ set_target_properties(sf PROPERTIES PREFIX "")
 target_link_libraries(sf ${ELF_LIBRARIES})
 
 # =================== build systemd ===================
-add_library(systemd SHARED
+add_library(sd SHARED
             ${PLUGIN_SOURCES}
             memory/zraminfo.cpp
             memory/swapinfo.cpp
@@ -414,6 +414,6 @@ add_library(systemd SHARED
             lib/lzo/lzo1x_decompress_safe.c
             lib/lz4/lz4_decompress.c
             systemd/journal.cpp)
-set_target_properties(systemd PROPERTIES PREFIX "")
-target_link_libraries(systemd ${ELF_LIBRARIES} ${SYSTEMD_LIBRARIES})
+set_target_properties(sd PROPERTIES PREFIX "")
+target_link_libraries(sd ${ELF_LIBRARIES} ${SYSTEMD_LIBRARIES})
 endif()

--- a/binder/binder.h
+++ b/binder/binder.h
@@ -18,38 +18,6 @@
 
 #include "plugin.h"
 
-class Binder : public ParserPlugin {
-public:
-    static const int BINDER_THREAD = 0x0001;
-    static const int BINDER_NODE = 0x0002;
-    static const int BINDER_REF = 0x0004;
-    static const int BINDER_ALLOC = 0x0008;
-
-    char* sched_name[7] = {
-        TO_CONST_STRING("SCHED_NORMAL"),
-        TO_CONST_STRING("SCHED_FIFO"),
-        TO_CONST_STRING("SCHED_RR"),
-        TO_CONST_STRING("SCHED_BATCH"),
-        TO_CONST_STRING("SCHED_ISO"),
-        TO_CONST_STRING("SCHED_IDLE"),
-        TO_CONST_STRING("SCHED_DEADLINE"),
-    };
-    Binder();
-
-    void cmd_main(void) override;
-    void print_binder_transaction_log_entry(bool fail_log);
-    void binder_proc_show(struct binder_argument_t* binder_arg);
-    void print_binder_alloc(struct task_context *tc,ulong alloc_addr);
-    void print_binder_proc(ulong proc_addr,int flags);
-    void print_binder_node_nilocked(ulong node_addr);
-    void print_binder_ref_olocked(ulong ref_addr);
-    void print_binder_thread_ilocked(ulong thread);
-    void print_binder_transaction_ilocked(ulong proc_addr, const char* prefix, ulong transaction);
-    void print_binder_work_ilocked(ulong proc_addr, const char* prefix, const char* transaction_prefix, ulong work);
-    char*convert_sched(int i);
-    DEFINE_PLUGIN_INSTANCE(Binder)
-};
-
 struct binder_argument_t {
     struct task_context *tc;
     int pid;
@@ -269,4 +237,38 @@ struct binder_node {
     struct kernel_list_head async_todo;
 };
 
+class Binder : public ParserPlugin {
+private:
+    static const int BINDER_THREAD = 0x0001;
+    static const int BINDER_NODE = 0x0002;
+    static const int BINDER_REF = 0x0004;
+    static const int BINDER_ALLOC = 0x0008;
+    char* sched_name[7] = {
+        TO_CONST_STRING("SCHED_NORMAL"),
+        TO_CONST_STRING("SCHED_FIFO"),
+        TO_CONST_STRING("SCHED_RR"),
+        TO_CONST_STRING("SCHED_BATCH"),
+        TO_CONST_STRING("SCHED_ISO"),
+        TO_CONST_STRING("SCHED_IDLE"),
+        TO_CONST_STRING("SCHED_DEADLINE"),
+    };
+
+    void print_binder_transaction_log_entry(bool fail_log);
+    void binder_proc_show(struct binder_argument_t* binder_arg);
+    void print_binder_alloc(struct task_context *tc,ulong alloc_addr);
+    void print_binder_proc(ulong proc_addr,int flags);
+    void print_binder_node_nilocked(ulong node_addr);
+    void print_binder_ref_olocked(ulong ref_addr);
+    void print_binder_thread_ilocked(ulong thread);
+    void print_binder_transaction_ilocked(ulong proc_addr, const char* prefix, ulong transaction);
+    void print_binder_work_ilocked(ulong proc_addr, const char* prefix, const char* transaction_prefix, ulong work);
+    char* convert_sched(int i);
+
+public:
+    Binder();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
+    DEFINE_PLUGIN_INSTANCE(Binder)
+};
 #endif // BINDER_DEFS_H_

--- a/bootlog/boot.cpp
+++ b/bootlog/boot.cpp
@@ -43,10 +43,13 @@ void BootInfo::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-BootInfo::BootInfo(){
+void BootInfo::init_offset(void) {
     field_init(kobject,name);
     field_init(device,kobj);
     field_init(device,driver_data);
+}
+
+void BootInfo::init_command(void) {
     cmd_name = "boot";
     help_str_list={
         "boot",                          /* command name */
@@ -75,8 +78,9 @@ BootInfo::BootInfo(){
         "    <6>[    0.000000][    T0] Enabling dynamic shadow call stack",
         "\n",
     };
-    initialize();
 }
+
+BootInfo::BootInfo(){}
 
 void BootInfo::read_pmic_pon_trigger_maps(){
     field_init(pmic_pon_trigger_mapping,code);

--- a/bootlog/boot.h
+++ b/bootlog/boot.h
@@ -26,41 +26,41 @@ struct pmic_event_t {
 };
 
 enum pmic_pon_event {
-	PMIC_PON_EVENT_PON_TRIGGER_RECEIVED	= 0x01,
-	PMIC_PON_EVENT_OTP_COPY_COMPLETE	= 0x02,
-	PMIC_PON_EVENT_TRIM_COMPLETE		= 0x03,
-	PMIC_PON_EVENT_XVLO_CHECK_COMPLETE	= 0x04,
-	PMIC_PON_EVENT_PMIC_CHECK_COMPLETE	= 0x05,
-	PMIC_PON_EVENT_RESET_TRIGGER_RECEIVED	= 0x06,
-	PMIC_PON_EVENT_RESET_TYPE		= 0x07,
-	PMIC_PON_EVENT_WARM_RESET_COUNT		= 0x08,
-	PMIC_PON_EVENT_FAULT_REASON_1_2		= 0x09,
-	PMIC_PON_EVENT_FAULT_REASON_3		= 0x0A,
-	PMIC_PON_EVENT_PBS_PC_DURING_FAULT	= 0x0B,
-	PMIC_PON_EVENT_FUNDAMENTAL_RESET	= 0x0C,
-	PMIC_PON_EVENT_PON_SEQ_START		= 0x0D,
-	PMIC_PON_EVENT_PON_SUCCESS		= 0x0E,
-	PMIC_PON_EVENT_WAITING_ON_PSHOLD	= 0x0F,
-	PMIC_PON_EVENT_PMIC_SID1_FAULT		= 0x10,
-	PMIC_PON_EVENT_PMIC_SID2_FAULT		= 0x11,
-	PMIC_PON_EVENT_PMIC_SID3_FAULT		= 0x12,
-	PMIC_PON_EVENT_PMIC_SID4_FAULT		= 0x13,
-	PMIC_PON_EVENT_PMIC_SID5_FAULT		= 0x14,
-	PMIC_PON_EVENT_PMIC_SID6_FAULT		= 0x15,
-	PMIC_PON_EVENT_PMIC_SID7_FAULT		= 0x16,
-	PMIC_PON_EVENT_PMIC_SID8_FAULT		= 0x17,
-	PMIC_PON_EVENT_PMIC_SID9_FAULT		= 0x18,
-	PMIC_PON_EVENT_PMIC_SID10_FAULT		= 0x19,
-	PMIC_PON_EVENT_PMIC_SID11_FAULT		= 0x1A,
-	PMIC_PON_EVENT_PMIC_SID12_FAULT		= 0x1B,
-	PMIC_PON_EVENT_PMIC_SID13_FAULT		= 0x1C,
-	PMIC_PON_EVENT_PMIC_VREG_READY_CHECK	= 0x20,
+    PMIC_PON_EVENT_PON_TRIGGER_RECEIVED    = 0x01,
+    PMIC_PON_EVENT_OTP_COPY_COMPLETE       = 0x02,
+    PMIC_PON_EVENT_TRIM_COMPLETE           = 0x03,
+    PMIC_PON_EVENT_XVLO_CHECK_COMPLETE     = 0x04,
+    PMIC_PON_EVENT_PMIC_CHECK_COMPLETE     = 0x05,
+    PMIC_PON_EVENT_RESET_TRIGGER_RECEIVED  = 0x06,
+    PMIC_PON_EVENT_RESET_TYPE              = 0x07,
+    PMIC_PON_EVENT_WARM_RESET_COUNT        = 0x08,
+    PMIC_PON_EVENT_FAULT_REASON_1_2        = 0x09,
+    PMIC_PON_EVENT_FAULT_REASON_3          = 0x0A,
+    PMIC_PON_EVENT_PBS_PC_DURING_FAULT     = 0x0B,
+    PMIC_PON_EVENT_FUNDAMENTAL_RESET       = 0x0C,
+    PMIC_PON_EVENT_PON_SEQ_START           = 0x0D,
+    PMIC_PON_EVENT_PON_SUCCESS             = 0x0E,
+    PMIC_PON_EVENT_WAITING_ON_PSHOLD       = 0x0F,
+    PMIC_PON_EVENT_PMIC_SID1_FAULT         = 0x10,
+    PMIC_PON_EVENT_PMIC_SID2_FAULT         = 0x11,
+    PMIC_PON_EVENT_PMIC_SID3_FAULT         = 0x12,
+    PMIC_PON_EVENT_PMIC_SID4_FAULT         = 0x13,
+    PMIC_PON_EVENT_PMIC_SID5_FAULT         = 0x14,
+    PMIC_PON_EVENT_PMIC_SID6_FAULT         = 0x15,
+    PMIC_PON_EVENT_PMIC_SID7_FAULT         = 0x16,
+    PMIC_PON_EVENT_PMIC_SID8_FAULT         = 0x17,
+    PMIC_PON_EVENT_PMIC_SID9_FAULT         = 0x18,
+    PMIC_PON_EVENT_PMIC_SID10_FAULT        = 0x19,
+    PMIC_PON_EVENT_PMIC_SID11_FAULT        = 0x1A,
+    PMIC_PON_EVENT_PMIC_SID12_FAULT        = 0x1B,
+    PMIC_PON_EVENT_PMIC_SID13_FAULT        = 0x1C,
+    PMIC_PON_EVENT_PMIC_VREG_READY_CHECK   = 0x20,
 };
 
 enum pmic_pon_reset_type {
-	PMIC_PON_RESET_TYPE_WARM_RESET		= 0x1,
-	PMIC_PON_RESET_TYPE_SHUTDOWN		= 0x4,
-	PMIC_PON_RESET_TYPE_HARD_RESET		= 0x7,
+    PMIC_PON_RESET_TYPE_WARM_RESET        = 0x1,
+    PMIC_PON_RESET_TYPE_SHUTDOWN          = 0x4,
+    PMIC_PON_RESET_TYPE_HARD_RESET        = 0x7,
 };
 
 class BootInfo : public ParserPlugin {
@@ -70,20 +70,22 @@ private:
     std::vector<std::string> pmic_pon_fault_reason1;
     std::vector<std::string> pmic_pon_fault_reason2;
     std::vector<std::string> pmic_pon_fault_reason3;
-
     std::vector<std::string> pmic_pon_s3_reset_reason;
     std::vector<std::string> pmic_pon_pon_pbl_status;
-	std::vector<std::string> pmic_pon_reset_type_label;
+    std::vector<std::string> pmic_pon_reset_type_label;
 
-public:
-    BootInfo();
     void read_pmic_pon_trigger_maps();
     void pmic_pon_log_print_reason(uint8_t data, std::vector<std::string> reasons);
     void parser_pmic_pon_log_dev(ulong addr);
     void print_pmic_info();
     void print_boot_log();
     std::string remove_invalid_chars(const std::string& msg);
+
+public:
+    BootInfo();
     void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(BootInfo)
 };
 

--- a/clock/clock.cpp
+++ b/clock/clock.cpp
@@ -27,6 +27,7 @@ void Clock::cmd_main(void) {
     std::string cppString;
     if (argcnt < 2) cmd_usage(pc->curcmd, SYNOPSIS);
     if (provider_list.size() == 0){
+        init_offset();
         parser_clk_providers();
     }
     while ((c = getopt(argcnt, args, "ctedp")) != EOF) {
@@ -55,7 +56,7 @@ void Clock::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-Clock::Clock(){
+void Clock::init_offset(void) {
     field_init(of_clk_provider,link);
     field_init(of_clk_provider,node);
     field_init(of_clk_provider,data);
@@ -94,6 +95,9 @@ Clock::Clock(){
     struct_init(qcom_cc);
     struct_init(rpm_smd_clk_desc);
     struct_init(clk_rpmh_desc);
+}
+
+void Clock::init_command(void) {
     cmd_name = "ccf";
     help_str_list={
         "ccf",                            /* command name */
@@ -163,7 +167,10 @@ Clock::Clock(){
         "    ffffff8017a8df00 gpu_cc_cx_gmu_clk                             19.2MHZ",
         "\n",
     };
-    initialize();
+}
+
+Clock::Clock(){
+    do_init_offset = false;
 }
 
 void Clock::parser_clk_of_msm_provider(std::shared_ptr<clk_provider> prov_ptr,ulong data){
@@ -312,11 +319,10 @@ void Clock::print_enable_clock(){
     fprintf(fp, "=============================================\n");
     fprintf(fp, "  Enable Clocks from of_clk_providers list\n");
     fprintf(fp, "=============================================\n");
-    std::ostringstream oss_h;
-    oss_h << std::left << std::setw(VADDR_PRLEN) << "clk_core"  << " "
+    std::ostringstream oss;
+    oss << std::left << std::setw(VADDR_PRLEN) << "clk_core"  << " "
           << std::left << std::setw(45) << "Name" << " "
-          << std::left << "Rate";
-    fprintf(fp, "%s \n",oss_h.str().c_str());
+          << std::left << "Rate" << "\n";
     for (const auto& provider : provider_list) {
         if (provider->core_list.size() == 0){
             continue;
@@ -333,25 +339,23 @@ void Clock::print_enable_clock(){
             ulong rate = read_ulong(core_addr + field_offset(clk_core,rate),"rate");
             int enable_count = read_uint(core_addr + field_offset(clk_core,enable_count),"enable");
             if(enable_count > 0){
-                std::ostringstream oss;
                 oss << std::left << std::setw(VADDR_PRLEN) << std::hex << core_addr << " "
                     << std::left << std::setw(45)  << core_name << " "
-                    << std::left << std::dec << (double)rate/1000000 << "MHZ";
-                fprintf(fp, "%s \n",oss.str().c_str());
+                    << std::left << std::dec << (double)rate/1000000 << "MHZ" << "\n";
             }
         }
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void Clock::print_disable_clock(){
     fprintf(fp, "=============================================\n");
     fprintf(fp, "  Disabled Clocks from of_clk_providers list\n");
     fprintf(fp, "=============================================\n");
-    std::ostringstream oss_h;
-    oss_h << std::left << std::setw(VADDR_PRLEN) << "clk_core"  << " "
+    std::ostringstream oss;
+    oss << std::left << std::setw(VADDR_PRLEN) << "clk_core"  << " "
           << std::left << std::setw(45) << "Name" << " "
-          << std::left << "Rate";
-    fprintf(fp, "%s \n",oss_h.str().c_str());
+          << std::left << "Rate" << "\n";
     for (const auto& provider : provider_list) {
         if (provider->core_list.size() == 0){
             continue;
@@ -369,25 +373,23 @@ void Clock::print_disable_clock(){
             int enable_count = read_uint(core_addr + field_offset(clk_core,enable_count),"enable");
             int prepare_count = read_uint(core_addr + field_offset(clk_core,prepare_count),"prepare");
             if(prepare_count == 0 && enable_count == 0){
-                std::ostringstream oss;
                 oss << std::left << std::setw(VADDR_PRLEN) << std::hex << core_addr << " "
                     << std::left << std::setw(45)  << core_name << " "
-                    << std::left << std::dec << (double)rate/1000000 << "MHZ";
-                fprintf(fp, "%s \n",oss.str().c_str());
+                    << std::left << std::dec << (double)rate/1000000 << "MHZ" << "\n";
             }
         }
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void Clock::print_prepare_clock(){
     fprintf(fp, "=============================================\n");
     fprintf(fp, "  Prepare Clocks from of_clk_providers list\n");
     fprintf(fp, "=============================================\n");
-    std::ostringstream oss_h;
-    oss_h << std::left << std::setw(VADDR_PRLEN) << "clk_core"  << " "
+    std::ostringstream oss;
+    oss << std::left << std::setw(VADDR_PRLEN) << "clk_core"  << " "
           << std::left << std::setw(45) << "Name" << " "
-          << std::left << "Rate";
-    fprintf(fp, "%s \n",oss_h.str().c_str());
+          << std::left << "Rate" << "\n";
     for (const auto& provider : provider_list) {
         if (provider->core_list.size() == 0){
             continue;
@@ -404,23 +406,23 @@ void Clock::print_prepare_clock(){
             ulong rate = read_ulong(core_addr + field_offset(clk_core,rate),"rate");
             int prepare_count = read_uint(core_addr + field_offset(clk_core,prepare_count),"prepare");
             if(prepare_count > 0){
-                std::ostringstream oss;
                 oss << std::left << std::setw(VADDR_PRLEN) << std::hex << core_addr << " "
                     << std::left << std::setw(45)  << core_name << " "
-                    << std::left << std::dec << (double)rate/1000000 << "MHZ";
-                fprintf(fp, "%s \n",oss.str().c_str());
+                    << std::left << std::dec << (double)rate/1000000 << "MHZ" << "\n";
             }
         }
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void Clock::print_clk_tree(){
     int offset = field_offset(clk,clks_node);
+    std::ostringstream oss;
     for (const auto& provider : provider_list) {
         if (provider->core_list.size() == 0){
             continue;
         }
-        fprintf(fp, "clk_provider:%s\n",provider->name.c_str());
+        oss << std::left << "clk_provider:" << std::hex << provider->addr << "  " << provider->name << "\n";
         for (const auto& core_addr : provider->core_list) {
             std::string core_name;
             ulong name_addr = read_pointer(core_addr + field_offset(clk_core,name),"name addr");
@@ -431,11 +433,9 @@ void Clock::print_clk_tree(){
                 core_name = "";
             }
             ulong rate = read_ulong(core_addr + field_offset(clk_core,rate),"rate");
-            std::ostringstream oss;
-            oss << std::left << "clk_core:" << std::hex << core_addr << "  "
+            oss << std::left << "    clk_core:" << std::hex << core_addr << "  "
                 << std::left << std::setw(45)  << core_name << " "
-                << std::left << std::dec << (double)rate/1000000 << "MHZ";
-            fprintf(fp, "   %s \n",oss.str().c_str());
+                << std::left << std::dec << (double)rate/1000000 << "MHZ" << "\n";
             ulong hlist_head = core_addr + field_offset(clk_core,clks);
             for (const auto& clk_addr : for_each_hlist(hlist_head, offset)) {
                 std::string dev_id;
@@ -448,20 +448,21 @@ void Clock::print_clk_tree(){
                 if (dev_id.empty()){
                     dev_id = "";
                 }
-                fprintf(fp, "           clk:%lx  --> device:%s \n",clk_addr, dev_id.c_str());
+                oss << std::left << "         clk:" << std::hex << clk_addr << "  --> device:" << dev_id << "\n";
             }
         }
-        fprintf(fp, "\n\n");
+        oss << "\n\n";
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void Clock::print_clk_providers(){
+    std::ostringstream oss;
     for (const auto& provider : provider_list) {
         if (provider->core_list.size() == 0){
             continue;
         }
         fprintf(fp, "clk_provider: %s\n",provider->name.c_str());
-        std::ostringstream oss;
         oss << std::left << std::setw(VADDR_PRLEN)   << "clk_core"  << " "
             << std::right << std::setw(10)   << "rate" << " "
             << std::right << std::setw(10)   << "req_rate" << " "
@@ -473,6 +474,7 @@ void Clock::print_clk_providers(){
             << std::left << std::setw(VADDR_PRLEN)    << "clk_hw" << " "
             << "Name";
         fprintf(fp, "   %s \n",oss.str().c_str());
+        oss.str("");
         for (const auto& addr : provider->core_list) {
             parser_clk_core(addr);
         }

--- a/clock/clock.h
+++ b/clock/clock.h
@@ -28,9 +28,6 @@ class Clock : public ParserPlugin {
 private:
     std::vector<std::shared_ptr<clk_provider>> provider_list;
 
-public:
-    Clock();
-
     void parser_clk_simple(std::shared_ptr<clk_provider> prov_ptr,ulong data);
     void parser_clk_hw_simple(std::shared_ptr<clk_provider> prov_ptr,ulong data);
     void parser_clk_rpmh(std::shared_ptr<clk_provider> prov_ptr, ulong data);
@@ -44,10 +41,15 @@ public:
     void print_enable_clock();
     void print_disable_clock();
     void print_prepare_clock();
-    void cmd_main(void) override;
     void parser_clk_providers();
     void print_clk_providers();
     void print_clk_tree();
+
+public:
+    Clock();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Clock)
 };
 

--- a/coredump/arm/arm.h
+++ b/coredump/arm/arm.h
@@ -80,24 +80,24 @@ struct elf32_prstatus {
 };
 
 class Arm : public Core {
-    public:
-        Arm(std::shared_ptr<Swapinfo> swap);
-        ~Arm();
-        void parser_prpsinfo() override;
-        void parser_siginfo() override;
-        void* parser_prstatus(ulong task_addr,int* data_size) override;
-        void* parser_nt_prfpreg(ulong task_addr) override;
-        void* parser_nt_arm_tls(ulong task_addr) override;
-        void* parser_nt_arm_hw_break(ulong task_addr) override;
-        void* parser_nt_arm_hw_watch(ulong task_addr) override;
-        void* parser_nt_arm_system_call(ulong task_addr) override;
-        void* parser_nt_arm_sve(ulong task_addr) override;
-        void* parser_nt_arm_pac_mask(ulong task_addr) override;
-        void* parser_nt_arm_pac_enabled_keys(ulong task_addr) override;
-        void* parser_nt_arm_paca_keys(ulong task_addr) override;
-        void* parser_nt_arm_pacg_keys(ulong task_addr) override;
-        void* parser_nt_arm_tagged_addr_ctrl(ulong task_addr) override;
-        void* parser_nt_arm_vfp(ulong task_addr) override;
+public:
+    Arm(std::shared_ptr<Swapinfo> swap);
+    ~Arm();
+    void parser_prpsinfo() override;
+    void parser_siginfo() override;
+    void* parser_prstatus(ulong task_addr,int* data_size) override;
+    void* parser_nt_prfpreg(ulong task_addr) override;
+    void* parser_nt_arm_tls(ulong task_addr) override;
+    void* parser_nt_arm_hw_break(ulong task_addr) override;
+    void* parser_nt_arm_hw_watch(ulong task_addr) override;
+    void* parser_nt_arm_system_call(ulong task_addr) override;
+    void* parser_nt_arm_sve(ulong task_addr) override;
+    void* parser_nt_arm_pac_mask(ulong task_addr) override;
+    void* parser_nt_arm_pac_enabled_keys(ulong task_addr) override;
+    void* parser_nt_arm_paca_keys(ulong task_addr) override;
+    void* parser_nt_arm_pacg_keys(ulong task_addr) override;
+    void* parser_nt_arm_tagged_addr_ctrl(ulong task_addr) override;
+    void* parser_nt_arm_vfp(ulong task_addr) override;
 };
 
 #endif // ARM_DEFS_H_

--- a/coredump/arm/arm64.h
+++ b/coredump/arm/arm64.h
@@ -71,24 +71,24 @@ struct elf64_prstatus {
 };
 
 class Arm64 : public Core {
-    public:
-        Arm64(std::shared_ptr<Swapinfo> swap);
-        ~Arm64();
-        void parser_prpsinfo() override;
-        void parser_siginfo() override;
-        void* parser_prstatus(ulong task_addr,int* data_size) override;
-        void* parser_nt_prfpreg(ulong task_addr) override;
-        void* parser_nt_arm_tls(ulong task_addr) override;
-        void* parser_nt_arm_hw_break(ulong task_addr) override;
-        void* parser_nt_arm_hw_watch(ulong task_addr) override;
-        void* parser_nt_arm_system_call(ulong task_addr) override;
-        void* parser_nt_arm_sve(ulong task_addr) override;
-        void* parser_nt_arm_pac_mask(ulong task_addr) override;
-        void* parser_nt_arm_pac_enabled_keys(ulong task_addr) override;
-        void* parser_nt_arm_paca_keys(ulong task_addr) override;
-        void* parser_nt_arm_pacg_keys(ulong task_addr) override;
-        void* parser_nt_arm_tagged_addr_ctrl(ulong task_addr) override;
-        void* parser_nt_arm_vfp(ulong task_addr) override;
+public:
+    Arm64(std::shared_ptr<Swapinfo> swap);
+    ~Arm64();
+    void parser_prpsinfo() override;
+    void parser_siginfo() override;
+    void* parser_prstatus(ulong task_addr,int* data_size) override;
+    void* parser_nt_prfpreg(ulong task_addr) override;
+    void* parser_nt_arm_tls(ulong task_addr) override;
+    void* parser_nt_arm_hw_break(ulong task_addr) override;
+    void* parser_nt_arm_hw_watch(ulong task_addr) override;
+    void* parser_nt_arm_system_call(ulong task_addr) override;
+    void* parser_nt_arm_sve(ulong task_addr) override;
+    void* parser_nt_arm_pac_mask(ulong task_addr) override;
+    void* parser_nt_arm_pac_enabled_keys(ulong task_addr) override;
+    void* parser_nt_arm_paca_keys(ulong task_addr) override;
+    void* parser_nt_arm_pacg_keys(ulong task_addr) override;
+    void* parser_nt_arm_tagged_addr_ctrl(ulong task_addr) override;
+    void* parser_nt_arm_vfp(ulong task_addr) override;
 };
 
 #endif // ARM64_DEFS_H_

--- a/coredump/arm/compat.h
+++ b/coredump/arm/compat.h
@@ -88,24 +88,24 @@ struct compat_elf_prstatus
 };
 
 class Compat : public Core {
-    public:
-        Compat(std::shared_ptr<Swapinfo> swap);
-        ~Compat();
-        void parser_prpsinfo() override;
-        void parser_siginfo() override;
-        void* parser_prstatus(ulong task_addr,int* data_size) override;
-        void* parser_nt_prfpreg(ulong task_addr) override;
-        void* parser_nt_arm_tls(ulong task_addr) override;
-        void* parser_nt_arm_hw_break(ulong task_addr) override;
-        void* parser_nt_arm_hw_watch(ulong task_addr) override;
-        void* parser_nt_arm_system_call(ulong task_addr) override;
-        void* parser_nt_arm_sve(ulong task_addr) override;
-        void* parser_nt_arm_pac_mask(ulong task_addr) override;
-        void* parser_nt_arm_pac_enabled_keys(ulong task_addr) override;
-        void* parser_nt_arm_paca_keys(ulong task_addr) override;
-        void* parser_nt_arm_pacg_keys(ulong task_addr) override;
-        void* parser_nt_arm_tagged_addr_ctrl(ulong task_addr) override;
-        void* parser_nt_arm_vfp(ulong task_addr) override;
+public:
+    Compat(std::shared_ptr<Swapinfo> swap);
+    ~Compat();
+    void parser_prpsinfo() override;
+    void parser_siginfo() override;
+    void* parser_prstatus(ulong task_addr,int* data_size) override;
+    void* parser_nt_prfpreg(ulong task_addr) override;
+    void* parser_nt_arm_tls(ulong task_addr) override;
+    void* parser_nt_arm_hw_break(ulong task_addr) override;
+    void* parser_nt_arm_hw_watch(ulong task_addr) override;
+    void* parser_nt_arm_system_call(ulong task_addr) override;
+    void* parser_nt_arm_sve(ulong task_addr) override;
+    void* parser_nt_arm_pac_mask(ulong task_addr) override;
+    void* parser_nt_arm_pac_enabled_keys(ulong task_addr) override;
+    void* parser_nt_arm_paca_keys(ulong task_addr) override;
+    void* parser_nt_arm_pacg_keys(ulong task_addr) override;
+    void* parser_nt_arm_tagged_addr_ctrl(ulong task_addr) override;
+    void* parser_nt_arm_vfp(ulong task_addr) override;
 };
 
 #endif // COMPAT_DEFS_H_

--- a/coredump/core.cpp
+++ b/coredump/core.cpp
@@ -23,7 +23,9 @@ std::string Core::symbols_path;
 
 void Core::cmd_main(void) {}
 
-Core::Core(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){
+void Core::init_command(void) {}
+
+void Core::init_offset(void) {
     field_init(user_regset_view,name);
     field_init(user_regset_view,regsets);
     field_init(user_regset_view,n);
@@ -58,6 +60,10 @@ Core::Core(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){
     field_init(inode, i_flags);
     field_init(address_space, host);
     field_init(inode, i_nlink);
+}
+
+Core::Core(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){
+    init_offset();
 }
 
 Core::~Core(){
@@ -522,8 +528,8 @@ std::string Core::vma_flags_to_str(unsigned long flags) {
 void Core::print_proc_mapping(){
     tc = pid_to_context(core_pid);
     task_ptr = std::make_shared<UTask>(swap_ptr, tc->task);
+    std::ostringstream oss;
     for (auto &vma_ptr : task_ptr->for_each_vma_list()){
-        std::ostringstream oss;
         oss << std::left << "VMA:" << std::hex << vma_ptr->addr << " ["
             << std::hex << vma_ptr->vm_start
             << "-"
@@ -531,9 +537,9 @@ void Core::print_proc_mapping(){
             << vma_flags_to_str(vma_ptr->vm_flags) << " "
             << std::right << std::setw(16) << std::setfill('0') << vma_ptr->vm_flags << " "
             << std::right << std::hex << std::setw(8) << std::setfill('0') << vma_ptr->vm_pgoff << " "
-            << vma_ptr->name;
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << vma_ptr->name << "\n";
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
     task_ptr.reset();
 }
 
@@ -1254,4 +1260,3 @@ void Core::print_linkmap(){
     task_ptr.reset();
 }
 #pragma GCC diagnostic pop
- 

--- a/coredump/core.cpp
+++ b/coredump/core.cpp
@@ -310,10 +310,9 @@ bool Core::write_pt_load(std::shared_ptr<vma_struct> vma_ptr, size_t phdr_pos, s
         }
     }
     if(replace == false){
-        void* vma_data = task_ptr->read_vma_data(vma_ptr);
-        if (vma_data){
-            fwrite(vma_data, vma_ptr->vm_size, 1, corefile);
-            std::free(vma_data);
+        std::vector<char> vma_data = task_ptr->read_vma_data(vma_ptr);
+        if (vma_data.size() > 0){
+            fwrite(vma_data.data(), vma_ptr->vm_size, 1, corefile);
         }
         data_pos += vma_ptr->vm_size;
     }

--- a/coredump/coredump.cpp
+++ b/coredump/coredump.cpp
@@ -95,6 +95,12 @@ void Coredump::cmd_main(void) {
     }
 }
 
+void Coredump::init_offset(void) {
+    field_init(task_struct, flags);
+    field_init(task_struct, thread_info);
+    field_init(thread_info, flags);
+}
+
 void Coredump::print_linkmap(int pid){
     if(get_core_parser(pid) && core_parser != nullptr){
         core_parser->set_core_pid(pid);
@@ -156,20 +162,13 @@ void Coredump::generate_coredump(int pid){
     }
 }
 
-Coredump::Coredump(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){
-    init_command();
-}
+Coredump::Coredump(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){}
 
 Coredump::Coredump(){
     swap_ptr = std::make_shared<Swapinfo>();
-    init_command();
-    //print_table();
 }
 
-void Coredump::init_command(){
-    field_init(task_struct, flags);
-    field_init(task_struct, thread_info);
-    field_init(thread_info, flags);
+void Coredump::init_command(void){
     ParserPlugin::cmd_name = "coredump";
     help_str_list={
         "coredump",                            /* command name */
@@ -206,7 +205,6 @@ void Coredump::init_command(){
         "      VMA:ffffff80279c05a0 [7befacb000-7befb14000] rw-p 0000000000100073 07befacb [anon:scudo:secondary]",
         "\n",
     };
-    initialize();
 }
 
 #pragma GCC diagnostic pop

--- a/coredump/coredump.h
+++ b/coredump/coredump.h
@@ -25,23 +25,25 @@
 
 class Coredump : public ParserPlugin {
 private:
+    static const int PRINT_LINKMAP = 0x0001;
+    static const int PRINT_PROCMAP = 0x0002;
+    static const int PRINT_COREDUMP = 0x0004;
     std::shared_ptr<Core> core_parser;
     std::shared_ptr<Swapinfo> swap_ptr;
     bool is_compat = false;
     bool debug = false;
 
-public:
-    static const int PRINT_LINKMAP = 0x0001;
-    static const int PRINT_PROCMAP = 0x0002;
-    static const int PRINT_COREDUMP = 0x0004;
-    Coredump();
-    Coredump(std::shared_ptr<Swapinfo> swap);
-    void init_command();
-    void cmd_main(void) override;
     void print_linkmap(int pid);
     void generate_coredump(int pid);
     bool get_core_parser(int pid);
     void print_proc_mapping(int pid);
+
+public:
+    Coredump();
+    Coredump(std::shared_ptr<Swapinfo> swap);
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Coredump)
 };
 

--- a/cpu/cpuinfo.cpp
+++ b/cpu/cpuinfo.cpp
@@ -49,7 +49,7 @@ void CpuInfo::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-CpuInfo::CpuInfo(){
+void CpuInfo::init_offset(void) {
     field_init(cpufreq_policy,cpu);
     field_init(cpufreq_policy,cpuinfo);
     field_init(cpufreq_policy,min);
@@ -62,6 +62,9 @@ CpuInfo::CpuInfo(){
 
     field_init(cpufreq_frequency_table,frequency);
     struct_init(cpufreq_frequency_table);
+}
+
+void CpuInfo::init_command(void) {
     cmd_name = "cpu";
     help_str_list={
         "cpu",                            /* command name */
@@ -101,32 +104,33 @@ CpuInfo::CpuInfo(){
         "       cpu_data:0xffffff887a9c5de0 cpu:4 disabled:false is_busy:false busy_pct:0",
         "\n",
     };
-    initialize();
 }
 
+CpuInfo::CpuInfo(){}
+
 void CpuInfo::print_cpu_policy(){
-    std::ostringstream oss_hd;
-    oss_hd  << std::left << std::setw(3)  << "CPU" << " "
+    std::ostringstream oss;
+    oss  << std::left << std::setw(3)  << "CPU" << " "
             << std::left << std::setw(20) << "cpufreq_policy" << " "
             << std::left << std::setw(7)  << "cluster" << " "
             << std::left << std::setw(10) << "cur_freq" << " "
             << std::left << std::setw(10) << "min_freq" << " "
             << std::left << std::setw(10) << "max_freq" << " "
-            << std::left << std::setw(10) << "governor" << " ";
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
+            << std::left << std::setw(10) << "governor" << " "
+            << "\n";
     int index = 0;
     for (const auto& cpu_ptr : cpu_infos) {
-        std::ostringstream oss;
         oss << std::left << std::setw(3)  << index << " "
             << std::left << std::setw(20) << std::hex << cpu_ptr->addr << " "
             << std::left << std::setw(7)  << std::dec << cpu_ptr->cluster << " "
             << std::left << std::setw(10) << std::dec << cpu_ptr->cur << " "
             << std::left << std::setw(10) << std::dec << cpu_ptr->min << " "
             << std::left << std::setw(10) << std::dec << cpu_ptr->max << " "
-            << std::left << std::setw(10) << cpu_ptr->gov_name << " ";
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << std::left << std::setw(10) << cpu_ptr->gov_name << " "
+            << "\n";
         index++;
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void CpuInfo::parser_cpu_policy(){
@@ -226,24 +230,26 @@ void CpuInfo::print_cpu_state(){
 void CpuInfo::print_freq_table(){
     size_t freq_cnt = 0;
     for (const auto& cpu_ptr : cpu_infos) {
-        freq_cnt = std::max(freq_cnt,cpu_ptr->freq_table.size());
+        freq_cnt = std::max(freq_cnt, cpu_ptr->freq_table.size());
     }
-    std::ostringstream oss_hd;
-    for (size_t i = 0; i < cpu_infos.size(); i++){
+    std::ostringstream oss;
+    for (size_t i = 0; i < cpu_infos.size(); i++) {
         std::string name = "CPU" + std::to_string(i);
-        oss_hd << std::left << std::setw(15) << name << " ";
+        oss << std::left << std::setw(15) << name << " ";
     }
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
-    for (size_t i = 0; i < freq_cnt; i++){
-        std::ostringstream oss;
+    fprintf(fp, "%s \n", oss.str().c_str());
+    for (size_t i = 0; i < freq_cnt; i++) {
+        oss.str("");
+        oss.clear();
         for (const auto& cpu_ptr : cpu_infos) {
-            if (cpu_ptr->freq_table.size() > i){
+            if (cpu_ptr->freq_table.size() > i) {
                 oss << std::left << std::setw(15) << cpu_ptr->freq_table[i] << " ";
-            }else{
+            } else {
                 oss << std::left << std::setw(15) << "N/A" << " ";
             }
         }
-        fprintf(fp, "%s \n",oss.str().c_str());
+        fprintf(fp, "%s \n", oss.str().c_str());
     }
 }
+
 #pragma GCC diagnostic pop

--- a/cpu/cpuinfo.h
+++ b/cpu/cpuinfo.h
@@ -39,14 +39,19 @@ struct cpu_data {
 };
 
 class CpuInfo : public ParserPlugin {
-public:
-    CpuInfo();
+private:
     std::vector<std::shared_ptr<cpu_policy>> cpu_infos;
+
     void print_cpu_policy();
     void print_cpu_state();
     void print_freq_table();
     void parser_cpu_policy();
+
+public:
+    CpuInfo();
     void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(CpuInfo)
 };
 

--- a/debugimage/cpu32_ctx.cpp
+++ b/debugimage/cpu32_ctx.cpp
@@ -40,25 +40,22 @@ void Cpu32_Context::print_stack(std::shared_ptr<Dump_entry> entry_ptr){
     struct syment *sym;
     ulong offset;
     sym = value_search(pc, &offset);
-    std::ostringstream oss_pc;
-    oss_pc << "Core" << std::dec << core << " ";
+    std::ostringstream oss;
+    oss << "Core" << std::dec << core << " " << "\n";
     if (sym) {
-        oss_pc << "PC: " << "<" << std::hex << pc << ">: " << sym->name  << "+" << std::hex << offset;
+        oss << "PC: " << "<" << std::hex << pc << ">: " << sym->name  << "+" << std::hex << offset << "\n";
     } else {
-        oss_pc << "PC: " << "<" << std::hex << pc << ">: " << "UNKNOWN"  << "+" << std::hex << 0;
+        oss << "PC: " << "<" << std::hex << pc << ">: " << "UNKNOWN"  << "+" << std::hex << 0 << "\n";
     }
-    fprintf(fp, "%s \n",oss_pc.str().c_str());
 
     lr = pac_ignore(lr);
     sym = value_search(lr, &offset);
-    std::ostringstream oss_lr;
-    oss_lr << "Core" << std::dec << core << " ";
     if (sym) {
-        oss_lr << "LR: " << "<" << std::hex << lr << ">: " << sym->name  << "+" << std::hex << offset;
+        oss << "LR: " << "<" << std::hex << lr << ">: " << sym->name  << "+" << std::hex << offset << "\n";
     } else {
-        oss_lr << "LR: " << "<" << std::hex << lr << ">: " << "UNKNOWN"  << "+" << std::hex << 0;
+        oss << "LR: " << "<" << std::hex << lr << ">: " << "UNKNOWN"  << "+" << std::hex << 0 << "\n";
     }
-    fprintf(fp, "%s \n\n",oss_lr.str().c_str());
+    fprintf(fp, "%s \n\n",oss.str().c_str());
     FREEBUF(buf);
 }
 

--- a/debugimage/cpu64_ctx_v13.cpp
+++ b/debugimage/cpu64_ctx_v13.cpp
@@ -33,25 +33,22 @@ void Cpu64_Context_V13::print_stack(std::shared_ptr<Dump_entry> entry_ptr){
     struct syment *sym;
     ulong offset;
     sym = value_search(pc, &offset);
-    std::ostringstream oss_pc;
-    oss_pc << "Core" << std::dec << core << " ";
+    std::ostringstream oss;
+    oss << "Core" << std::dec << core << " " << "\n";
     if (sym) {
-        oss_pc << "PC: " << "<" << std::hex << pc << ">: " << sym->name  << "+" << std::hex << offset;
+        oss << "PC: " << "<" << std::hex << pc << ">: " << sym->name  << "+" << std::hex << offset << "\n";
     } else {
-        oss_pc << "PC: " << "<" << std::hex << pc << ">: " << "UNKNOWN"  << "+" << std::hex << 0;
+        oss << "PC: " << "<" << std::hex << pc << ">: " << "UNKNOWN"  << "+" << std::hex << 0 << "\n";
     }
-    fprintf(fp, "%s \n",oss_pc.str().c_str());
 
     lr = pac_ignore(lr);
     sym = value_search(lr, &offset);
-    std::ostringstream oss_lr;
-    oss_lr << "Core" << std::dec << core << " ";
     if (sym) {
-        oss_lr << "LR: " << "<" << std::hex << lr << ">: " << sym->name  << "+" << std::hex << offset;
+        oss << "LR: " << "<" << std::hex << lr << ">: " << sym->name  << "+" << std::hex << offset << "\n";
     } else {
-        oss_lr << "LR: " << "<" << std::hex << lr << ">: " << "UNKNOWN"  << "+" << std::hex << 0;
+        oss << "LR: " << "<" << std::hex << lr << ">: " << "UNKNOWN"  << "+" << std::hex << 0 << "\n";
     }
-    fprintf(fp, "%s \n\n",oss_lr.str().c_str());
+    fprintf(fp, "%s \n\n",oss.str().c_str());
 #if defined(ARM64)
     struct task_context *tc;
     tc = task_to_context(tt->active_set[core]);

--- a/debugimage/cpu64_ctx_v14.cpp
+++ b/debugimage/cpu64_ctx_v14.cpp
@@ -83,25 +83,22 @@ void Cpu64_Context_V14::print_stack(std::shared_ptr<Dump_entry> entry_ptr){
     struct syment *sym;
     ulong offset;
     sym = value_search(pc, &offset);
-    std::ostringstream oss_pc;
-    oss_pc << "Core" << std::dec << core << " ";
+    std::ostringstream oss;
+    oss << "Core" << std::dec << core << " " << "\n";
     if (sym) {
-        oss_pc << "PC: " << "<" << std::hex << pc << ">: " << sym->name  << "+" << std::hex << offset;
+        oss << "PC: " << "<" << std::hex << pc << ">: " << sym->name  << "+" << std::hex << offset << "\n";
     } else {
-        oss_pc << "PC: " << "<" << std::hex << pc << ">: " << "UNKNOWN"  << "+" << std::hex << 0;
+        oss << "PC: " << "<" << std::hex << pc << ">: " << "UNKNOWN"  << "+" << std::hex << 0 << "\n";
     }
-    fprintf(fp, "%s \n",oss_pc.str().c_str());
 
     lr = pac_ignore(lr);
     sym = value_search(lr, &offset);
-    std::ostringstream oss_lr;
-    oss_lr << "Core" << std::dec << core << " ";
     if (sym) {
-        oss_lr << "LR: " << "<" << std::hex << lr << ">: " << sym->name  << "+" << std::hex << offset;
+        oss << "LR: " << "<" << std::hex << lr << ">: " << sym->name  << "+" << std::hex << offset << "\n";
     } else {
-        oss_lr << "LR: " << "<" << std::hex << lr << ">: " << "UNKNOWN"  << "+" << std::hex << 0;
+        oss << "LR: " << "<" << std::hex << lr << ">: " << "UNKNOWN"  << "+" << std::hex << 0 << "\n";
     }
-    fprintf(fp, "%s \n",oss_lr.str().c_str());
+    fprintf(fp, "%s \n",oss.str().c_str());
 #if defined(ARM64)
     struct task_context *tc;
     tc = task_to_context(tt->active_set[core]);

--- a/debugimage/cpu64_ctx_v14.h
+++ b/debugimage/cpu64_ctx_v14.h
@@ -118,9 +118,11 @@ typedef struct {
 }tzbsp_dump_64_1_4_t;
 
 class Cpu64_Context_V14 : public ImageParser {
+private:
+    void compute_pc(sysdbg_cpu64_ctx_1_4_t reg, sysdbg_neon128_registers_t neon_reg);
+
 public:
     Cpu64_Context_V14();
-    void compute_pc(sysdbg_cpu64_ctx_1_4_t reg, sysdbg_neon128_registers_t neon_reg);
     void generate_cmm(std::shared_ptr<Dump_entry> entry_ptr) override;
     void print_stack(std::shared_ptr<Dump_entry> entry_ptr) override;
 };

--- a/debugimage/cpu64_ctx_v20.cpp
+++ b/debugimage/cpu64_ctx_v20.cpp
@@ -145,25 +145,22 @@ void Cpu64_Context_V20::print_stack(std::shared_ptr<Dump_entry> entry_ptr){
             pc = pac_ignore(pc);
             ulong offset;
             struct syment *sym = value_search(pc, &offset);
-            std::ostringstream oss_pc;
-            oss_pc << "Core" << std::dec << core << " ";
+            std::ostringstream oss;
+            oss << "Core" << std::dec << core << " " << "\n";
             if (sym) {
-                oss_pc << "PC: " << "<" << std::hex << pc << ">: " << sym->name  << "+" << std::hex << offset;
+                oss << "PC: " << "<" << std::hex << pc << ">: " << sym->name  << "+" << std::hex << offset << "\n";
             } else {
-                oss_pc << "PC: " << "<" << std::hex << pc << ">: " << "UNKNOWN"  << "+" << std::hex << 0;
+                oss << "PC: " << "<" << std::hex << pc << ">: " << "UNKNOWN"  << "+" << std::hex << 0 << "\n";
             }
-            fprintf(fp, "%s \n",oss_pc.str().c_str());
 
             lr = pac_ignore(lr);
             sym = value_search(lr, &offset);
-            std::ostringstream oss_lr;
-            oss_lr << "Core" << std::dec << core << " ";
             if (sym) {
-                oss_lr << "LR: " << "<" << std::hex << lr << ">: " << sym->name  << "+" << std::hex << offset;
+                oss << "LR: " << "<" << std::hex << lr << ">: " << sym->name  << "+" << std::hex << offset << "\n";
             } else {
-                oss_lr << "LR: " << "<" << std::hex << lr << ">: " << "UNKNOWN"  << "+" << std::hex << 0;
+                oss << "LR: " << "<" << std::hex << lr << ">: " << "UNKNOWN"  << "+" << std::hex << 0 << "\n";
             }
-            fprintf(fp, "%s \n",oss_lr.str().c_str());
+            fprintf(fp, "%s \n",oss.str().c_str());
 #if defined(ARM64)
             struct task_context *tc;
             tc = task_to_context(tt->active_set[core]);

--- a/debugimage/cpu64_ctx_v20.h
+++ b/debugimage/cpu64_ctx_v20.h
@@ -114,9 +114,10 @@ private:
     int32_t regset_size = 0;
     std::map<int, std::string> dump_regset_ids;
 
+    void compute_pc(sysdbg_cpu64_ctx_2_0_gprs_t &reg, sysdbg_cpu64_ctx_2_0_el1_t &ctx_el1_reg);
+
 public:
     Cpu64_Context_V20();
-    void compute_pc(sysdbg_cpu64_ctx_2_0_gprs_t &reg, sysdbg_cpu64_ctx_2_0_el1_t &ctx_el1_reg);
     void generate_cmm(std::shared_ptr<Dump_entry> entry_ptr) override;
     void print_stack(std::shared_ptr<Dump_entry> entry_ptr) override;
     uint32_t get_vcpu_index(uint32_t affinity) override;

--- a/debugimage/debugimage.cpp
+++ b/debugimage/debugimage.cpp
@@ -71,7 +71,27 @@ void DebugImage::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-DebugImage::DebugImage(){
+void DebugImage::init_offset(void) {
+    field_init(msm_memory_dump,table_phys);
+    field_init(msm_dump_table,version);
+    field_init(msm_dump_table,num_entries);
+    field_init(msm_dump_table,entries);
+    field_init(msm_dump_entry,id);
+    field_init(msm_dump_entry,name);
+    field_init(msm_dump_entry,type);
+    field_init(msm_dump_entry,addr);
+    field_init(msm_dump_data,version);
+    field_init(msm_dump_data,magic);
+    field_init(msm_dump_data,name);
+    field_init(msm_dump_data,addr);
+    field_init(msm_dump_data,len);
+    field_init(msm_dump_data,reserved);
+    struct_init(msm_dump_table);
+    struct_init(msm_dump_entry);
+    struct_init(msm_dump_data);
+}
+
+void DebugImage::init_command(void) {
     cmd_name = "dbi";
     help_str_list={
         "dbi",                            /* command name */
@@ -200,31 +220,32 @@ DebugImage::DebugImage(){
     if (cpu_index_offset == -1){
         cpu_index_offset = 0x10;
     }
-    initialize();
+}
+
+DebugImage::DebugImage(){
+    do_init_offset = false;
 }
 
 void DebugImage::print_memdump(){
-    std::ostringstream oss_hd;
-    oss_hd  << std::left << std::setw(4)            << "Id" << " "
+    std::ostringstream oss;
+    oss  << std::left << std::setw(4)            << "Id" << " "
             << std::left << std::setw(16)           << "Dump_entry" << " "
             << std::left << std::setw(8)            << "version" << " "
             << std::left << std::setw(VADDR_PRLEN)  << "magic" << " "
             << std::left << std::setw(VADDR_PRLEN)  << "DataAddr" << " "
             << std::left << std::setw(10)           << "DataLen" << " "
-            << std::left << "Name";
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
+            << std::left << "Name" << "\n";;
     // parse_dump_v2
     for (const auto& entry_ptr : image_list) {
-        std::ostringstream oss;
         oss << std::left << std::setw(4)            << std::dec << entry_ptr->id << " "
             << std::left << std::setw(16)           << std::hex << entry_ptr->addr << " "
             << std::left << std::setw(8)            << std::dec << entry_ptr->version << " "
             << std::left << std::setw(VADDR_PRLEN)  << std::hex << entry_ptr->magic << " "
             << std::left << std::setw(VADDR_PRLEN)  << std::hex << entry_ptr->data_addr << " "
             << std::left << std::setw(10)           << std::dec << entry_ptr->data_len << " "
-            << std::left  << entry_ptr->data_name;
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << std::left  << entry_ptr->data_name << "\n";;
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void DebugImage::parser_memdump(){
@@ -241,23 +262,7 @@ void DebugImage::parser_memdump(){
         fprintf(fp, "memdump address is invalid!\n");
         return;
     }
-    field_init(msm_memory_dump,table_phys);
-    field_init(msm_dump_table,version);
-    field_init(msm_dump_table,num_entries);
-    field_init(msm_dump_table,entries);
-    field_init(msm_dump_entry,id);
-    field_init(msm_dump_entry,name);
-    field_init(msm_dump_entry,type);
-    field_init(msm_dump_entry,addr);
-    field_init(msm_dump_data,version);
-    field_init(msm_dump_data,magic);
-    field_init(msm_dump_data,name);
-    field_init(msm_dump_data,addr);
-    field_init(msm_dump_data,len);
-    field_init(msm_dump_data,reserved);
-    struct_init(msm_dump_table);
-    struct_init(msm_dump_entry);
-    struct_init(msm_dump_data);
+    init_offset();
     uint64_t table_phys = read_ulonglong(dump_addr + field_offset(msm_memory_dump,table_phys),"table_phys");
     // fprintf(fp, "DumpTable base:%" PRIx64 "\n", table_phys);
     parser_dump_table(table_phys);

--- a/debugimage/debugimage.h
+++ b/debugimage/debugimage.h
@@ -99,11 +99,7 @@ private:
     bool debug = false;
     int32_t cpu_index_offset = 0;
 
-public:
-    DebugImage();
     void print_memdump();
-    void cmd_main(void) override;
-    DEFINE_PLUGIN_INSTANCE(DebugImage)
     void parser_memdump();
     void parser_debugimage(ulong addr);
     void print_cpu_stack();
@@ -115,6 +111,13 @@ public:
     std::set<ulong> find_x29(const std::map<ulong, ulong>& addr_x29);
     void print_task_stack(int pid);
     void print_irq_stack(int cpu);
+
+public:
+    DebugImage();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
+    DEFINE_PLUGIN_INSTANCE(DebugImage)
 };
 
 #endif // DEBUG_IMAGE_DEFS_H_

--- a/debugimage/image_parser.cpp
+++ b/debugimage/image_parser.cpp
@@ -19,13 +19,13 @@
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
 
-void ImageParser::cmd_main(void) {
+void ImageParser::cmd_main(void) {}
 
-}
+ImageParser::ImageParser(){}
 
-ImageParser::ImageParser(){
+void ImageParser::init_offset(void) {}
 
-}
+void ImageParser::init_command(void) {}
 
 uint32_t ImageParser::get_vcpu_index(uint32_t affinity) {
     return 0;

--- a/debugimage/image_parser.h
+++ b/debugimage/image_parser.h
@@ -21,12 +21,16 @@
 struct Dump_entry;
 
 class ImageParser : public ParserPlugin {
-public:
-    ImageParser();
+protected:
     uint64_t createMask(int a, int b);
     uint64_t pac_ignore(uint64_t data);
     std::string get_cmm_path(std::string name, bool secure);
+
+public:
+    ImageParser();
     void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     virtual void generate_cmm(std::shared_ptr<Dump_entry> entry_ptr)=0;
     virtual void print_stack(std::shared_ptr<Dump_entry> entry_ptr)=0;
     virtual uint32_t get_vcpu_index(uint32_t affinity);

--- a/device_driver/dd.h
+++ b/device_driver/dd.h
@@ -64,13 +64,11 @@ struct partition {
 };
 
 class DDriver : public ParserPlugin {
-public:
+private:
     std::vector<std::shared_ptr<bus_type>> bus_list;
     std::vector<std::shared_ptr<class_type>> class_list;
-    DDriver();
 
     void print_class_info();
-    void cmd_main(void) override;
     void print_bus_info();
     void print_device_list();
     void print_device_driver_for_bus(std::string bus_name);
@@ -91,6 +89,12 @@ public:
     std::shared_ptr<driver> parser_driver(size_t addr);
     std::vector<std::shared_ptr<driver>> parser_driver_list(std::string bus_name);
     std::shared_ptr<device> parser_device(size_t addr);
+
+public:
+    DDriver();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(DDriver)
 };
 

--- a/devicetree/devicetree.cpp
+++ b/devicetree/devicetree.cpp
@@ -121,9 +121,9 @@ std::vector<std::shared_ptr<Property>> Devicetree::read_propertys(ulong addr){
         prop->length = length;
         ulong value_addr = ULONG(prop_buf + field_offset(property,value));
         if(length > 0){
-            prop->value = malloc(length);
+            prop->value.resize(length);
             void *prop_val = read_memory(value_addr,length,"property_value");
-            memcpy(prop->value, prop_val, length);
+            memcpy(prop->value.data(), prop_val, length);
             FREEBUF(prop_val);
         }
         res.push_back(prop);
@@ -146,7 +146,7 @@ std::vector<DdrRange> Devicetree::get_ddr_size(){
         if (prop == nullptr){
             continue;
         }
-        std::string tempstr = (char *)prop->value;
+        std::string tempstr = (char *)prop->value.data();
         if (tempstr != "memory"){
             continue;
         }
@@ -161,7 +161,7 @@ std::vector<DdrRange> Devicetree::get_ddr_size(){
 
 std::vector<DdrRange> Devicetree::parse_memory_regs(std::shared_ptr<Property> prop){
     std::vector<DdrRange> result;
-    char* ptr = reinterpret_cast<char*>(prop->value);
+    char* ptr = reinterpret_cast<char*>(prop->value.data());
     // prop->length how many byte of this prop val
     size_t reg_cnt = prop->length / 4;
     size_t regs[reg_cnt];

--- a/devicetree/devicetree.cpp
+++ b/devicetree/devicetree.cpp
@@ -19,6 +19,24 @@
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
 Devicetree::Devicetree(){
+    init_offset();
+    if (!csymbol_exists("of_root")){
+        fprintf(fp,  "of_root doesn't exist in this kernel!\n");
+        return;
+    }
+    ulong of_root_addr = csymbol_value("of_root");
+    if (!is_kvaddr(of_root_addr)) {
+        fprintf(fp, "of_root address is invalid!\n");
+        return;
+    }
+    root_addr = read_pointer(of_root_addr,"of_root");
+}
+
+void Devicetree::cmd_main(void) {}
+
+void Devicetree::init_command(void) {}
+
+void Devicetree::init_offset(void) {
     field_init(device_node,name);
     field_init(device_node,phandle);
     field_init(device_node,full_name);
@@ -34,21 +52,6 @@ Devicetree::Devicetree(){
 
     struct_init(device_node);
     struct_init(property);
-
-    if (!csymbol_exists("of_root")){
-        fprintf(fp,  "of_root doesn't exist in this kernel!\n");
-        return;
-    }
-    ulong of_root_addr = csymbol_value("of_root");
-    if (!is_kvaddr(of_root_addr)) {
-        fprintf(fp, "of_root address is invalid!\n");
-        return;
-    }
-    root_addr = read_pointer(of_root_addr,"of_root");
-}
-
-void Devicetree::cmd_main(void) {
-    // TODO
 }
 
 std::shared_ptr<Property> Devicetree::getprop(ulong node_addr,const std::string& name){

--- a/devicetree/devicetree.h
+++ b/devicetree/devicetree.h
@@ -27,7 +27,7 @@ struct Property {
     ulong addr;
     int length;
     std::string name;
-    void *value;
+    std::vector<char> value;
 };
 
 struct device_node {

--- a/devicetree/devicetree.h
+++ b/devicetree/devicetree.h
@@ -72,23 +72,29 @@ private:
         "strength",
     };
 
-public:
-    Devicetree();
-    ulong root_addr;
-    std::shared_ptr<device_node> root_node;
+private:
     std::unordered_map<ulong, std::shared_ptr<device_node>> node_addr_maps;
     std::unordered_map<std::string, std::shared_ptr<device_node>> node_path_maps;
 
+    std::vector<DdrRange> parse_memory_regs(std::shared_ptr<Property> prop);
+
+public:
+    ulong root_addr;
+    std::shared_ptr<device_node> root_node;
+
+    Devicetree();
     void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     std::shared_ptr<Property> getprop(ulong node_addr,const std::string& name);
-    std::vector<DdrRange> get_ddr_size();
     std::vector<std::shared_ptr<device_node>> find_node_by_name(const std::string& name);
     std::shared_ptr<device_node> find_node_by_addr(ulong addr);
     bool is_str_prop(const std::string& name);
     bool is_int_prop(const std::string& name);
-    std::vector<DdrRange> parse_memory_regs(std::shared_ptr<Property> prop);
+    std::vector<DdrRange> get_ddr_size();
     std::vector<std::shared_ptr<Property>> read_propertys(ulong addr);
     std::shared_ptr<device_node> read_node(const std::string& path, ulong node_addr);
+
 };
 
 #endif // DEVICE_TREE_DEFS_H_

--- a/devicetree/dts.cpp
+++ b/devicetree/dts.cpp
@@ -20,7 +20,7 @@
 
 #ifndef BUILD_TARGET_TOGETHER
 DEFINE_PLUGIN_COMMAND(Dts)
-#endif // !BUILD_TARGET_TOGETHER
+#endif
 
 void Dts::cmd_main(void) {
     int c;
@@ -80,14 +80,16 @@ void Dts::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-Dts::Dts(){
+void Dts::init_offset(void) {}
+
+void Dts::init_command(void) {
     cmd_name = "dts";
     help_str_list={
         "dts",                            /* command name */
         "dump dts info",        /* short description */
         "-a \n"
             "  dts -f\n"
-            "  dts -b\n"
+            "  dts -b <path of *.dtb>\n"
             "  dts -n <name>\n"
             "  dts -m\n"
             "  This command dumps the dts info.",
@@ -135,8 +137,9 @@ Dts::Dts(){
         "           dtc -I dtb -O dts -o ./xx.dts ./dts.dtb",
         "\n",
     };
-    initialize();
 }
+
+Dts::Dts(){}
 
 void Dts::print_ddr_info(){
     ulong total_size = 0;
@@ -144,17 +147,18 @@ void Dts::print_ddr_info(){
     fprintf(fp, "DDR memory ranges:\n");
     fprintf(fp, "===================================================\n");
     int index = 1;
+    std::ostringstream oss;
     for (auto it = ranges.begin(); it != ranges.end(); ++it) {
         DdrRange item = *it;
-        std::ostringstream oss;
-        oss << "[" << std::setw(2) << std::setfill('0') << index << "]"
+        oss << "[" << std::setw(2) << std::setfill('0') << std::right << std::dec << index << "]"
             << "<" << std::left << std::hex  << std::setfill(' ') << std::setw(10) << item.address
             << "~" << std::right << std::hex  << std::setfill(' ') << std::setw(10) << (item.address + item.size) << "> "
-            << ": " << std::left << csize(item.size);
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << ": " << std::left << csize(item.size)
+            << "\n";
         total_size += item.size;
         index++;
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
     fprintf(fp, "===================================================\n");
     fprintf(fp, "Total size:%s\n",csize(total_size).c_str());
 }

--- a/devicetree/dts.cpp
+++ b/devicetree/dts.cpp
@@ -267,7 +267,7 @@ void Dts::print_properties(std::vector<std::shared_ptr<Property>> props,int leve
     for (auto it = props.begin(); it != props.end(); ++it) {
         std::shared_ptr<Property> ptr = *it;
         std::string prop_name = ptr->name;
-        void* prop_val = ptr->value;
+        void* prop_val = ptr->value.data();
         ulong prop_addr = ptr->addr;
         int prop_length = ptr->length;
         for (int i = 0; i < prop_level; i++) {

--- a/devicetree/dts.h
+++ b/devicetree/dts.h
@@ -21,19 +21,22 @@
 
 class Dts : public Devicetree {
 private:
-
-public:
-    Dts();
     static const int DTS_SHOW = 0x0001;
     static const int DTS_ADDR = 0x0002;
     static const int DTS_PATH = 0x0004;
     static const int DTB_MAX_SIZE = 0x100000;
-    void cmd_main(void) override;
+
     void print_ddr_info();
     void read_dtb(std::string& path);
     void print_node(std::shared_ptr<device_node> node_ptr,int level,int flag);
     void print_node(std::shared_ptr<device_node> node_ptr,int flag);
     void print_properties(std::vector<std::shared_ptr<Property>> props,int level,bool is_symbol,int flag);
+
+public:
+    Dts();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Dts)
 };
 

--- a/icc/icc.cpp
+++ b/icc/icc.cpp
@@ -54,7 +54,7 @@ void ICC::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-ICC::ICC(){
+void ICC::init_offset(void) {
     field_init(icc_provider,provider_list);
     field_init(icc_provider,nodes);
     field_init(icc_provider,dev);
@@ -78,6 +78,9 @@ ICC::ICC(){
     field_init(icc_req,avg_bw);
     field_init(icc_req,peak_bw);
     struct_init(icc_req);
+}
+
+void ICC::init_command(void) {
     cmd_name = "icc";
     help_str_list={
         "icc",                            /* command name */
@@ -123,107 +126,104 @@ ICC::ICC(){
         "    ffffff80157b7a10 true    0    1          1          4a80000.i2c",
         "\n",
     };
-    initialize();
 }
 
+ICC::ICC(){}
+
 void ICC::print_icc_request(std::string node_name){
+    std::ostringstream oss;
     for (const auto& provider_ptr : provider_list) {
         for (const auto& node_ptr : provider_ptr->node_list) {
             if (node_ptr->name != node_name){
                 continue;
             }
             if(node_ptr->req_list.size() == 0) return;
-            std::ostringstream oss_hd;
-            oss_hd  << std::left << std::setw(VADDR_PRLEN)  << "icc_req" << " "
+            oss  << std::left << std::setw(VADDR_PRLEN)  << "icc_req" << " "
                     << std::left << std::setw(7)            << "enabled" << " "
                     << std::left << std::setw(4)            << "tag" << " "
                     << std::left << std::setw(10)           << "avg_bw" << " "
                     << std::left << std::setw(10)           << "peak_bw" << " "
-                    << std::left << "Name";
-            fprintf(fp, "%s \n",oss_hd.str().c_str());
+                    << std::left << "Name" << "\n";
             for (const auto& req_ptr : node_ptr->req_list) {
-                std::ostringstream oss;
                 oss << std::left << std::setw(VADDR_PRLEN)  << std::hex << req_ptr->addr << " "
                     << std::left << std::setw(7)            << (req_ptr->enabled ? "true": "false") << " "
                     << std::left << std::setw(4)            << std::dec << req_ptr->tag << " "
                     << std::left << std::setw(10)           << std::dec << req_ptr->avg_bw << " "
                     << std::left << std::setw(10)           << std::dec << req_ptr->peak_bw << " "
-                    << std::left << req_ptr->name;
-                fprintf(fp, "%s \n",oss.str().c_str());
+                    << std::left << req_ptr->name << "\n";
             }
         }
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void ICC::print_icc_nodes(std::string provider_name){
+    std::ostringstream oss;
     for (const auto& provider_ptr : provider_list) {
         if (provider_ptr->name != provider_name){
             continue;
         }
         if(provider_ptr->node_list.size() == 0) return;
-        std::ostringstream oss_hd;
-        oss_hd  << std::left << std::setw(VADDR_PRLEN)  << "icc_node" << " "
+        oss  << std::left << std::setw(VADDR_PRLEN)  << "icc_node" << " "
                 << std::left << std::setw(5)            << "id" << " "
                 << std::left << std::setw(10)           << "avg_bw" << " "
                 << std::left << std::setw(10)           << "peak_bw" << " "
                 << std::left << std::setw(16)  << "qcom_icc_node" << " "
-                << std::left << "Name";
-        fprintf(fp, "%s \n",oss_hd.str().c_str());
+                << std::left << "Name" "\n";
         for (const auto& node_ptr : provider_ptr->node_list) {
-            std::ostringstream oss;
             oss << std::left << std::setw(VADDR_PRLEN)  << std::hex << node_ptr->addr << " "
                 << std::left << std::setw(5)            << std::dec << node_ptr->id << " "
                 << std::left << std::setw(10)           << std::dec << node_ptr->avg_bw << " "
                 << std::left << std::setw(10)           << std::dec << node_ptr->peak_bw << " "
                 << std::left << std::setw(16)           << std::hex << node_ptr->data << " "
-                << std::left << node_ptr->name;
-            fprintf(fp, "%s \n",oss.str().c_str());
+                << std::left << node_ptr->name << "\n";
         }
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void ICC::print_icc_info(){
+    std::ostringstream oss;
     for (const auto& provider_ptr : provider_list) {
-        std::ostringstream provider;
-        provider << std::left << "icc_provider:"   << std::hex << provider_ptr->addr << " "
-            << std::left << provider_ptr->name;
-        fprintf(fp, "%s \n",provider.str().c_str());
+        oss << std::left << "icc_provider:"   << std::hex << provider_ptr->addr << " "
+            << std::left << provider_ptr->name
+            << "\n";
         for (const auto& node_ptr : provider_ptr->node_list) {
-            std::ostringstream node;
-            node << std::left << "    icc_node:"  << std::hex << node_ptr->addr << " "
-                << std::left << "avg_bw:" << std::dec << node_ptr->avg_bw << " "
-                << std::left << "peak_bw:" << std::dec << node_ptr->peak_bw << " "
-                << std::left << "[" << node_ptr->name << "]";
-            fprintf(fp, "%s \n",node.str().c_str());
+            oss << std::left << "      icc_node:"  << std::hex << node_ptr->addr << " "
+                << std::left << "avg_bw:" << std::left << std::setw(10) << std::dec << node_ptr->avg_bw << " "
+                << std::left << "peak_bw:" << std::left << std::setw(10) << std::dec << node_ptr->peak_bw << " "
+                << std::left << "[" << node_ptr->name << "]"
+                << "\n";
             for (const auto& req_ptr : node_ptr->req_list) {
-                std::ostringstream req;
-                req << std::left << "       icc_req:" << std::hex << req_ptr->addr << " "
-                    << std::left << "avg_bw:" << std::dec << req_ptr->avg_bw << " "
-                    << std::left << "peak_bw:" << std::dec << req_ptr->peak_bw << " "
-                    << std::left << "[" << req_ptr->name << "]";
-                fprintf(fp, "%s \n",req.str().c_str());
+                oss << std::left << "       icc_req:" << std::hex << req_ptr->addr << " "
+                    << std::left << "avg_bw:" << std::left << std::setw(10) << std::dec << req_ptr->avg_bw << " "
+                    << std::left << "peak_bw:" << std::left << std::setw(10) << std::dec << req_ptr->peak_bw << " "
+                    << std::left << "[" << req_ptr->name << "]"
+                    << "\n";
             }
+            oss << "\n";
         }
-        fprintf(fp, "\n\n");
+        oss << "\n\n";
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void ICC::print_icc_provider(){
     if(provider_list.size() == 0) return;
-    std::ostringstream oss_hd;
-    oss_hd  << std::left << std::setw(VADDR_PRLEN)   << "icc_provider" << " "
+    std::ostringstream oss;
+    oss  << std::left << std::setw(VADDR_PRLEN)   << "icc_provider" << " "
             << std::left << std::setw(5)    << "users" << " "
             // << std::left << std::setw(VADDR_PRLEN)    << "data" << " "
-            << std::left << "Name";
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
+            << std::left << "Name"
+            << "\n";
     for (const auto& provider_ptr : provider_list) {
-        std::ostringstream oss;
         oss << std::left << std::setw(VADDR_PRLEN)   << std::hex << provider_ptr->addr << " "
             << std::left << std::setw(5)    << std::dec << provider_ptr->users << " "
             // << std::left << std::setw(VADDR_PRLEN)    << std::hex << provider_ptr->data << " "
-            << std::left << provider_ptr->name;
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << std::left << provider_ptr->name
+            << "\n";
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void ICC::parser_icc_provider(){

--- a/icc/icc.h
+++ b/icc/icc.h
@@ -48,16 +48,19 @@ class ICC : public ParserPlugin {
 private:
     std::vector<std::shared_ptr<icc_provider>> provider_list;
 
-public:
-    ICC();
     void print_icc_request(std::string node_name);
     void print_icc_nodes(std::string provider_name);
     void print_icc_info();
     void print_icc_provider();
-    void cmd_main(void) override;
     void parser_icc_provider();
     void parser_icc_node(std::shared_ptr<icc_provider> provider_ptr, ulong head);
     void parser_icc_req(std::shared_ptr<icc_node> node_ptr, ulong head);
+
+public:
+    ICC();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(ICC)
 };
 

--- a/ipc/ipc.h
+++ b/ipc/ipc.h
@@ -45,16 +45,21 @@ struct ipc_log {
 #define IPC_LOGGING_MAGIC_NUM       0x52784425
 
 class IPCLog : public ParserPlugin {
-public:
-    IPCLog();
+private:
     std::vector<std::shared_ptr<ipc_log>> ipc_list;
-    void cmd_main(void) override;
+
     void parser_ipc_log();
     void print_ipc_info();
     void save_ipc_log();
     void print_ipc_log(std::string name);
     void parser_ipc_log_page(std::shared_ptr<ipc_log> log_ptr);
     void appendBuffer(std::vector<char> &destBuf, void *sourceBuf, size_t length);
+
+public:
+    IPCLog();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(IPCLog)
 };
 

--- a/logcat/Logcat_parser.cpp
+++ b/logcat/Logcat_parser.cpp
@@ -34,6 +34,8 @@ static const std::unordered_map<std::string, LOG_ID> stringToLogID = {
     {"all", ALL}
 };
 
+void Logcat_Parser::init_offset(void) {}
+
 void Logcat_Parser::cmd_main(void) {
     int c;
     std::string cppString;
@@ -135,17 +137,15 @@ void Logcat_Parser::cmd_main(void) {
 
 Logcat_Parser::Logcat_Parser(std::shared_ptr<Swapinfo> swap,std::shared_ptr<PropInfo> prop)
     : swap_ptr(swap),prop_ptr(prop){
-    init_command();
 }
 
 Logcat_Parser::Logcat_Parser(){
-    init_command();
     swap_ptr = std::make_shared<Swapinfo>();
     prop_ptr = std::make_shared<PropInfo>(swap_ptr);
     //print_table();
 }
 
-void Logcat_Parser::init_command(){
+void Logcat_Parser::init_command(void){
     cmd_name = "logcat";
     help_str_list={
         "logcat",                            /* command name */
@@ -168,7 +168,6 @@ void Logcat_Parser::init_command(){
         "    %s> logcat -b events",
         "\n",
     };
-    initialize();
 }
 
 #pragma GCC diagnostic pop

--- a/logcat/Logcat_parser.h
+++ b/logcat/Logcat_parser.h
@@ -39,8 +39,9 @@ private:
 public:
     Logcat_Parser();
     Logcat_Parser(std::shared_ptr<Swapinfo> swap,std::shared_ptr<PropInfo> prop);
-    void init_command();
     void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Logcat_Parser)
 };
 

--- a/logcat/logcat.cpp
+++ b/logcat/logcat.cpp
@@ -567,9 +567,11 @@ Logcat::~Logcat(){
 
 }
 
-void Logcat::cmd_main(void) {
+void Logcat::init_offset(void) {}
 
-}
+void Logcat::cmd_main(void) {}
+
+void Logcat::init_command(void) {}
 
 std::string Logcat::getLogLevelChar(LogLevel level) {
     switch (level) {
@@ -633,6 +635,7 @@ std::string Logcat::remove_invalid_chars(const std::string& msg) {
 
 void Logcat::print_logcat_log(LOG_ID id){
     // fprintf(fp, "log_list len:%zu  \n", log_list.size());
+    std::ostringstream oss;
     for (auto &log_ptr : log_list){
         if(id != ALL && log_ptr->logid != id){
             // std::cout << log_ptr->msg << std::endl;
@@ -645,7 +648,6 @@ void Logcat::print_logcat_log(LOG_ID id){
         while (vaild_msg.back() == ' ' || vaild_msg.back() == '\n' || vaild_msg.back() == '\r'){
             vaild_msg.pop_back();
         }
-        std::ostringstream oss;
         if (log_ptr->logid == MAIN || log_ptr->logid == SYSTEM || log_ptr->logid == RADIO
             || log_ptr->logid == CRASH || log_ptr->logid == KERNEL){
             oss << std::setw(18) << std::left << log_ptr->timestamp << " "
@@ -654,7 +656,8 @@ void Logcat::print_logcat_log(LOG_ID id){
                 << std::setw(6) << std::right << log_ptr->uid << " "
                 << getLogLevelChar(log_ptr->priority) << " "
                 << log_ptr->tag << " "
-                << vaild_msg;
+                << vaild_msg
+                << "\n";
         }else{ // event log
             std::string tag = log_ptr->tag;
             try {
@@ -671,10 +674,11 @@ void Logcat::print_logcat_log(LOG_ID id){
             << std::setw(6) << std::right << log_ptr->uid << " "
             << getLogLevelChar(log_ptr->priority) << " "
             << tag << " "
-            << vaild_msg;
+            << vaild_msg
+            << "\n";
         }
-        fprintf(fp, "%s \n",oss.str().c_str());
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 LogEvent Logcat::get_event(size_t pos, char* data, size_t len) {
@@ -811,6 +815,7 @@ void Logcat::parser_event_log(std::shared_ptr<LogEntry> log_ptr,char* logbuf, ui
     const size_t header_size = sizeof(android_event_header_t);
     size_t pos = 0;
     char* msg_ptr = logbuf;
+    std::ostringstream oss;
     while (pos < msg_len){
         if (pos + header_size > msg_len){
             break;
@@ -820,7 +825,6 @@ void Logcat::parser_event_log(std::shared_ptr<LogEntry> log_ptr,char* logbuf, ui
         pos += header_size;
         // read the tag
         log_ptr->tag = std::to_string(head.tag);
-        std::ostringstream oss;
         oss << std::left << ":[";
         LogEvent event = get_event(pos, msg_ptr, msg_len);
         if (event.type == -1) {
@@ -844,8 +848,9 @@ void Logcat::parser_event_log(std::shared_ptr<LogEntry> log_ptr,char* logbuf, ui
         } else {
             oss << event.val;
         }
-        oss << "]";
+        oss << "]" << "\n";
         log_ptr->msg = oss.str();
+        oss.str("");
     }
 }
 

--- a/logcat/logcat.h
+++ b/logcat/logcat.h
@@ -107,7 +107,7 @@ struct log_time {
 };
 
 class Logcat : public ParserPlugin {
-protected:
+private:
     const std::array<LogLevel, 9> priorityMap = {{
         LogLevel::LOG_UNKNOWN,
         LogLevel::LOG_DEFAULT,
@@ -119,29 +119,32 @@ protected:
         LogLevel::LOG_FATAL,
         LogLevel::LOG_SILENT
     }};
-    std::shared_ptr<UTask> task_ptr;
+
     std::string remove_invalid_chars(const std::string &str);
+    LogEvent get_event(size_t pos, char *data, size_t len);
+    std::string getLogLevelChar(LogLevel level);
 
 public:
-    static bool is_LE;
     bool debug = false;
-    Logcat(std::shared_ptr<Swapinfo> swap);
-    ~Logcat();
-    std::vector<std::shared_ptr<LogEntry>> log_list;
-    struct task_context *tc_logd;
+    static bool is_LE;
     std::string logd_symbol;
+    std::vector<std::shared_ptr<LogEntry>> log_list;
+    std::shared_ptr<UTask> task_ptr;
+    struct task_context *tc_logd;
     std::shared_ptr<Swapinfo> swap_ptr;
 
-    void cmd_main(void) override;
-    void parser_logcat_log();
-    void print_logcat_log(LOG_ID id);
-    LogEvent get_event(size_t pos, char *data, size_t len);
-    std::string formatTime(uint32_t tv_sec, long tv_nsec);
-    std::string find_symbol(std::string name);
+    Logcat(std::shared_ptr<Swapinfo> swap);
+    ~Logcat();
+    size_t get_stdlist(std::function<bool (std::shared_ptr<vma_struct>)> vma_callback, std::function<bool (ulong)> obj_callback);
     void parser_system_log(std::shared_ptr<LogEntry> log_ptr, char *logbuf, uint16_t msg_len);
     void parser_event_log(std::shared_ptr<LogEntry> log_ptr, char *logbuf, uint16_t msg_len);
-    std::string getLogLevelChar(LogLevel level);
-    size_t get_stdlist(std::function<bool (std::shared_ptr<vma_struct>)> vma_callback, std::function<bool (ulong)> obj_callback);
+    void parser_logcat_log();
+    void print_logcat_log(LOG_ID id);
+    std::string formatTime(uint32_t tv_sec, long tv_nsec);
+    std::string find_symbol(std::string name);
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     virtual ulong parser_logbuf_addr()=0;
     virtual void parser_logbuf(ulong buf_addr)=0;
     virtual size_t get_logbuf_addr_from_bss()=0;

--- a/logcat/logcatLE.cpp
+++ b/logcat/logcatLE.cpp
@@ -18,9 +18,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
-LogcatLE::LogcatLE(std::shared_ptr<Swapinfo> swap) : Logcat(swap){
-
-}
+LogcatLE::LogcatLE(std::shared_ptr<Swapinfo> swap) : Logcat(swap){}
 
 ulong LogcatLE::parser_logbuf_addr(){
     size_t logbuf_addr;

--- a/logcat/logcatR.cpp
+++ b/logcat/logcatR.cpp
@@ -18,9 +18,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
-LogcatR::LogcatR(std::shared_ptr<Swapinfo> swap) : Logcat(swap){
-
-}
+LogcatR::LogcatR(std::shared_ptr<Swapinfo> swap) : Logcat(swap){}
 
 ulong LogcatR::parser_logbuf_addr(){
     size_t logbuf_addr;

--- a/logcat/logcatS.cpp
+++ b/logcat/logcatS.cpp
@@ -18,9 +18,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
-LogcatS::LogcatS(std::shared_ptr<Swapinfo> swap) : Logcat(swap){
-
-}
+LogcatS::LogcatS(std::shared_ptr<Swapinfo> swap) : Logcat(swap){}
 
 void LogcatS::init_datatype_info(){
     field_init(SerializedLogBuffer, logs_);

--- a/logcat/logcatS.h
+++ b/logcat/logcatS.h
@@ -73,6 +73,7 @@ private:
     const size_t vtbl_size = 10;
     struct logcat_offset_table g_offset;
     struct logcat_size_table g_size;
+
     void init_datatype_info();
     ulong parser_logbuf_addr() override;
     size_t get_SerializedLogBuffer_from_vma();

--- a/memory/buddy.h
+++ b/memory/buddy.h
@@ -58,15 +58,13 @@ struct pglist_data {
 };
 
 class Buddy : public ParserPlugin {
-public:
+private:
     std::vector<std::shared_ptr<pglist_data>> node_list;
     std::vector<std::string> migratetype_names;
     int min_free_kbytes;
     int user_min_free_kbytes;
     int watermark_scale_factor;
-    Buddy();
 
-    void cmd_main(void) override;
     void parser_buddy_info();
     std::shared_ptr<pglist_data> parser_node_info(ulong addr);
     std::shared_ptr<zone> parser_zone_info(ulong addr);
@@ -78,6 +76,12 @@ public:
     void print_memory_zone(std::string addr);
     void print_node_info(std::shared_ptr<pglist_data> node_ptr);
     void print_zone_info(std::shared_ptr<zone> zone_ptr);
+
+public:
+    Buddy();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Buddy)
 };
 

--- a/memory/cma.h
+++ b/memory/cma.h
@@ -29,16 +29,20 @@ struct cma_mem {
 };
 
 class Cma : public ParserPlugin {
-public:
+private:
     std::vector<std::shared_ptr<cma_mem>> mem_list;
-    Cma();
 
-    void cmd_main(void) override;
     void parser_cma_areas();
     int get_cma_used_size(std::shared_ptr<cma_mem> cma);
     void print_cma_areas();
     void print_cma_page_status(std::string name,bool alloc);
     ulong cma_bitmap_maxno(std::shared_ptr<cma_mem> cma);
+
+public:
+    Cma();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Cma)
 };
 

--- a/memory/dmabuf/cmd_buf.cpp
+++ b/memory/dmabuf/cmd_buf.cpp
@@ -28,10 +28,13 @@ void DmaIon::cmd_main(void) {
     if (argcnt < 2) cmd_usage(pc->curcmd, SYNOPSIS);
     if(dmabuf_ptr == nullptr){
         dmabuf_ptr = std::make_shared<Dmabuf>();
+        dmabuf_ptr->get_dmabuf_from_proc();
+        dmabuf_ptr->parser_dma_bufs();
     }
     if(heap_ptr == nullptr){
         if(struct_size(dma_heap) != -1){
             heap_ptr = std::make_shared<DmaHeap>(dmabuf_ptr);
+            heap_ptr->parser_heaps();
         }else if(struct_size(ion_heap) != -1){
             heap_ptr = std::make_shared<IonHeap>(dmabuf_ptr);
         }
@@ -81,9 +84,12 @@ void DmaIon::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-DmaIon::DmaIon(){
+void DmaIon::init_offset(void) {
     struct_init(dma_heap);
     struct_init(ion_heap);
+}
+
+void DmaIon::init_command(void) {
     // print_table();
     cmd_name = "dmabuf";
     help_str_list={
@@ -171,7 +177,8 @@ DmaIon::DmaIon(){
         "       Save dmabuf to file xxx/dma_buf@ffffff88d0010400.data !",
         "\n",
     };
-    initialize();
 }
+
+DmaIon::DmaIon(){}
 
 #pragma GCC diagnostic pop

--- a/memory/dmabuf/cmd_buf.h
+++ b/memory/dmabuf/cmd_buf.h
@@ -30,6 +30,8 @@ private:
 public:
     DmaIon();
     void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(DmaIon)
 };
 

--- a/memory/dmabuf/dma_heap.cpp
+++ b/memory/dmabuf/dma_heap.cpp
@@ -26,7 +26,6 @@ DmaHeap::DmaHeap(std::shared_ptr<Dmabuf> dmabuf) : Heap(dmabuf){
     field_init(dma_heap,list);
     field_init(dma_heap,ops);
     struct_init(dma_heap);
-    parser_heaps();
 }
 
 void DmaHeap::print_heaps(){
@@ -36,30 +35,28 @@ void DmaHeap::print_heaps(){
         name_max_len = std::max(name_max_len,heap_ptr->name.size());
         ops_max_len = std::max(ops_max_len,heap_ptr->ops.size());
     }
-    std::ostringstream oss_hd;
-    oss_hd << std::left << std::setw(VADDR_PRLEN + 2) << "dma_heap" << " "
+    std::ostringstream oss;
+    oss << std::left << std::setw(VADDR_PRLEN + 2) << "dma_heap" << " "
         << std::left << std::setw(name_max_len + 2) << "Name" << " "
         << std::left << std::setw(4) << "ref" << " "
         << std::left << std::setw(ops_max_len + 2) << "ops" << " "
         << std::left << std::setw(VADDR_PRLEN + 2) << "priv" << " "
         << std::left << std::setw(7) << "buf_cnt" << " "
-        << std::left << "total_size";
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
+        << std::left << "total_size" << " \n";
     for (const auto& heap_ptr : dma_heaps) {
         size_t total_size = 0;
         for (const auto& dma_buf : heap_ptr->bufs) {
             total_size += dma_buf->size;
         }
-        std::ostringstream oss;
         oss << std::left << std::hex << std::setw(VADDR_PRLEN + 2) << heap_ptr->addr << " "
             << std::left << std::setw(name_max_len + 2) << heap_ptr->name << " "
             << std::left << std::dec << std::setw(4) << heap_ptr->refcount << " "
             << std::left << std::setw(ops_max_len + 2) << heap_ptr->ops << " "
             << std::left << std::hex << std::setw(VADDR_PRLEN + 2) << heap_ptr->priv_addr << " "
             << std::left << std::dec << std::setw(7) << heap_ptr->bufs.size() << " "
-            << std::left << csize(total_size);
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << std::left << csize(total_size) << " \n";
     }
+    fprintf(fp, "%s", oss.str().c_str());
 }
 
 void DmaHeap::print_heap(std::string name){
@@ -92,13 +89,13 @@ void DmaHeap::parser_ion_system_heap(std::shared_ptr<dma_heap> heap_ptr){
         return;
     }
     fprintf(fp, "%s: \n",heap_ptr->name.c_str());
-    std::ostringstream oss_hd;
-    oss_hd  << std::left  << std::setw(VADDR_PRLEN + 2) << "page_pool" << " "
+    std::ostringstream oss;
+    oss  << std::left  << std::setw(VADDR_PRLEN + 2) << "page_pool" << " "
         << std::left << std::setw(5) << "order" << " "
         << std::left << std::setw(10) << "high" << " "
         << std::left << std::setw(10) << "low" << " "
         << std::left << std::setw(10) << "total";
-    fprintf(fp, "   %s \n",oss_hd.str().c_str());
+    fprintf(fp, "   %s \n",oss.str().c_str());
     for (size_t i = 0; i < 3; i++){
         ulong pool_addr = read_pointer(pools_addr + i * sizeof(void *),"pool");
         if (!is_kvaddr(pool_addr)){

--- a/memory/dmabuf/dma_heap.h
+++ b/memory/dmabuf/dma_heap.h
@@ -31,16 +31,19 @@ struct dma_heap {
 };
 
 class DmaHeap : public Heap {
-public:
+private:
     std::vector<std::shared_ptr<dma_heap>> dma_heaps;
+
+    void parser_ion_system_heap(std::shared_ptr<dma_heap> heap_ptr);
+    void parser_dynamic_page_pool(ulong addr);
+    void print_heap(std::string name);
+
+public:
     DmaHeap(std::shared_ptr<Dmabuf> dmabuf);
     std::vector<ulong> get_heaps() override;
     void parser_heaps() override;
     void print_heaps() override;
     void print_system_heap_pool() override;
-    void parser_ion_system_heap(std::shared_ptr<dma_heap> heap_ptr);
-    void parser_dynamic_page_pool(ulong addr);
-    void print_heap(std::string name);
 };
 
 #endif // DMA_HEAP_DEFS_H_

--- a/memory/dmabuf/dmabuf.h
+++ b/memory/dmabuf/dmabuf.h
@@ -70,31 +70,36 @@ class Dmabuf : public ParserPlugin {
 private:
     std::vector<std::string> directions = { "DMA_BIDIRECTIONAL", "DMA_TO_DEVICE", "DMA_FROM_DEVICE", "DMA_NONE" };
 
-public:
-    std::vector<std::shared_ptr<proc_info>> proc_list;
-    std::vector<std::shared_ptr<dma_buf>> buf_list;
-    Dmabuf();
-    void cmd_main(void) override;
-    void parser_dma_bufs();
     std::shared_ptr<dma_buf> parser_dma_buf(ulong addr);
     void parser_buffer(std::shared_ptr<dma_buf> buf_ptr);
     bool sg_is_chain(ulong page_link);
     bool sg_is_last(ulong page_link);
     ulong sg_chain_ptr(ulong page_link);
     ulong sg_next(ulong sgl_addr, ulong page_link);
-    void parser_sg_table(std::shared_ptr<dma_buf> buf_ptr);
-    void get_dmabuf_from_proc();
     void get_proc_info(std::shared_ptr<dma_buf> buf_ptr);
     std::vector<std::shared_ptr<attachment>> parser_attachments(ulong list_head);
-    void print_dma_buf_list();
     void print_attachment(std::shared_ptr<dma_buf> buf_ptr);
-    void print_dma_buf(std::shared_ptr<dma_buf> buf_ptr);
     void print_proc_info(std::shared_ptr<dma_buf> buf_ptr);
     void print_sg_table(std::shared_ptr<dma_buf> buf_ptr);
+
+public:
+    std::vector<std::shared_ptr<proc_info>> proc_list;
+    std::vector<std::shared_ptr<dma_buf>> buf_list;
+
+    Dmabuf();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     void print_dma_buf(std::string addr);
-    void save_dma_buf(std::string addr);
+    void print_dma_buf_list();
     void print_procs();
     void print_proc(ulong pid);
+    void save_dma_buf(std::string addr);
+    void print_dma_buf(std::shared_ptr<dma_buf> buf_ptr);
+    void get_dmabuf_from_proc();
+    void parser_sg_table(std::shared_ptr<dma_buf> buf_ptr);
+    void parser_dma_bufs();
+
 };
 
 #endif // DMABUF_DEFS_H_

--- a/memory/dmabuf/heap.cpp
+++ b/memory/dmabuf/heap.cpp
@@ -19,11 +19,11 @@
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
 
-void Heap::cmd_main(void) {
+void Heap::cmd_main(void) {}
 
-}
+void Heap::init_offset(void) {}
 
-Heap::Heap(std::shared_ptr<Dmabuf> dmabuf): dmabuf_ptr(dmabuf){
+void Heap::init_command(void) {}
 
-}
+Heap::Heap(std::shared_ptr<Dmabuf> dmabuf): dmabuf_ptr(dmabuf){}
 #pragma GCC diagnostic pop

--- a/memory/dmabuf/heap.h
+++ b/memory/dmabuf/heap.h
@@ -25,12 +25,14 @@ protected:
 
 public:
     Heap(std::shared_ptr<Dmabuf> dmabuf);
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     virtual std::vector<ulong> get_heaps()=0;
     virtual void parser_heaps()=0;
     virtual void print_heaps()=0;
     virtual void print_system_heap_pool()=0;
     virtual void print_heap(std::string name)=0;
-    void cmd_main(void) override;
 };
 
 #endif // HEAP_DEFS_H_

--- a/memory/dmabuf/ion_heap.cpp
+++ b/memory/dmabuf/ion_heap.cpp
@@ -46,18 +46,17 @@ void IonHeap::print_heaps(){
         name_max_len = std::max(name_max_len,heap_ptr->name.size());
         ops_max_len = std::max(ops_max_len,heap_ptr->ops.size());
     }
-    std::ostringstream oss_hd;
-    oss_hd << std::left << std::setw(3) << "Id" << " "
+    std::ostringstream oss;
+    oss << std::left << std::setw(3) << "Id" << " "
         << std::left << std::setw(VADDR_PRLEN + 2) << "ion_heap" << " "
         << std::left << std::setw(22) << "type" << " "
         << std::left << std::setw(name_max_len + 2) << "Name" << " "
         << std::left << std::setw(6) << "flags" << " "
         << std::left << std::setw(ops_max_len + 2) << "ops" << " "
         << std::left << std::setw(7) << "buf_cnt" << " "
-        << std::left << "total_size";
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
+        << std::left << "total_size"
+        << "\n";
     for (const auto& heap_ptr : ion_heaps) {
-        std::ostringstream oss;
         oss << std::left << std::dec << std::setw(3) << heap_ptr->id << " "
             << std::left << std::hex << std::setw(VADDR_PRLEN + 2) << heap_ptr->addr << " "
             << std::left << std::setw(22) << heap_type[heap_ptr->type] << " "
@@ -65,9 +64,10 @@ void IonHeap::print_heaps(){
             << std::left << std::dec << std::setw(6) << heap_ptr->flags << " "
             << std::left << std::setw(ops_max_len + 2) << heap_ptr->ops << " "
             << std::left << std::dec << std::setw(7) << heap_ptr->buf_cnt << " "
-            << std::left << csize(heap_ptr->total_allocated);
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << std::left << csize(heap_ptr->total_allocated)
+            << "\n";
     }
+    fprintf(fp, "%s \n", oss.str().c_str());
 }
 
 void IonHeap::print_system_heap_pool(){
@@ -89,13 +89,13 @@ void IonHeap::parser_ion_system_heap(ulong addr){
     field_init(ion_system_heap,pools);
     ulong heap_addr = addr - field_offset(ion_system_heap,heap);
     fprintf(fp, "pools: \n");
-    std::ostringstream oss_hd1;
-    oss_hd1  << std::left  << std::setw(VADDR_PRLEN + 2) << "page_pool" << " "
+    std::ostringstream oss;
+    oss  << std::left  << std::setw(VADDR_PRLEN + 2) << "page_pool" << " "
         << std::left << std::setw(5) << "order" << " "
         << std::left << std::setw(10) << "high" << " "
         << std::left << std::setw(10) << "low" << " "
         << std::left << std::setw(10) << "total";
-    fprintf(fp, "   %s \n",oss_hd1.str().c_str());
+    fprintf(fp, "   %s \n", oss.str().c_str());
     size_t pools_cnt = field_size(ion_system_heap,pools)/sizeof(void *);
     ulong pools_addr = heap_addr + field_offset(ion_system_heap,pools);
     for (size_t i = 0; i < pools_cnt; i++){
@@ -115,14 +115,14 @@ void IonHeap::parser_ion_msm_system_heap(ulong addr){
     field_init(msm_ion_heap,ion_heap);
     ulong heap_addr = addr - field_offset(msm_ion_heap,ion_heap) - field_offset(ion_msm_system_heap,heap);
     fprintf(fp, "uncached_pools: \n");
-    std::ostringstream oss_hd1;
-    oss_hd1  << std::left  << std::setw(VADDR_PRLEN + 2) << "page_pool" << " "
+    std::ostringstream oss;
+    oss  << std::left  << std::setw(VADDR_PRLEN + 2) << "page_pool" << " "
         << std::left << std::setw(5) << "order" << " "
         << std::left << std::setw(10) << "high" << " "
         << std::left << std::setw(10) << "low" << " "
         << std::left << std::setw(10) << "total" << " "
-        << std::left << "cached";
-    fprintf(fp, "   %s \n",oss_hd1.str().c_str());
+        << std::left << "cached"
+        << "\n";
     size_t uncached_pools_cnt = field_size(ion_msm_system_heap,uncached_pools)/sizeof(void *);
     ulong uncached_pools_addr = heap_addr + field_offset(ion_msm_system_heap,uncached_pools);
     for (size_t i = 0; i < uncached_pools_cnt; i++){
@@ -133,15 +133,14 @@ void IonHeap::parser_ion_msm_system_heap(ulong addr){
         parser_ion_msm_page_pool(pools_addr);
     }
 
-    fprintf(fp, "\n\ncached_pools: \n");
-    std::ostringstream oss_hd2;
-    oss_hd2  << std::left  << std::setw(VADDR_PRLEN + 2) << "page_pool" << " "
+    oss << "\n\ncached_pools: \n";
+    oss  << std::left  << std::setw(VADDR_PRLEN + 2) << "page_pool" << " "
         << std::left << std::setw(5) << "order" << " "
         << std::left << std::setw(10) << "high" << " "
         << std::left << std::setw(10) << "low" << " "
         << std::left << std::setw(10) << "total" << " "
-        << std::left << "cached";
-    fprintf(fp, "   %s \n",oss_hd2.str().c_str());
+        << std::left << "cached"
+        << "\n";
     size_t cached_pools_cnt = field_size(ion_msm_system_heap,cached_pools)/sizeof(void *);
     ulong cached_pools_addr = heap_addr + field_offset(ion_msm_system_heap,cached_pools);
     for (size_t i = 0; i < uncached_pools_cnt; i++){
@@ -152,15 +151,15 @@ void IonHeap::parser_ion_msm_system_heap(ulong addr){
         parser_ion_msm_page_pool(pools_addr);
     }
 
-    fprintf(fp, "\n\nsecure_pools: \n");
-    std::ostringstream oss_hd3;
-    oss_hd3  << std::left  << std::setw(VADDR_PRLEN + 2) << "page_pool" << " "
+    oss << "\n\nsecure_pools: \n";
+    oss  << std::left  << std::setw(VADDR_PRLEN + 2) << "page_pool" << " "
         << std::left << std::setw(5) << "order" << " "
         << std::left << std::setw(10) << "high" << " "
         << std::left << std::setw(10) << "low" << " "
         << std::left << std::setw(10) << "total" << " "
-        << std::left << "cached";
-    fprintf(fp, "   %s \n",oss_hd3.str().c_str());
+        << std::left << "cached"
+        << "\n";
+    fprintf(fp, "   %s \n", oss.str().c_str());
     size_t secure_pools_cnt = field_size(ion_msm_system_heap,secure_pools)/sizeof(void *)/cached_pools_cnt;
     ulong secure_pools_addr = heap_addr + field_offset(ion_msm_system_heap,secure_pools);
     for (size_t i = 0; i < secure_pools_cnt; i++){

--- a/memory/dmabuf/ion_heap.h
+++ b/memory/dmabuf/ion_heap.h
@@ -41,11 +41,8 @@ struct ion_heap {
 class IonHeap : public Heap {
 private:
     std::unordered_map<int, std::string> heap_type;
-
-public:
-    IonHeap(std::shared_ptr<Dmabuf> dmabuf);
-
     std::vector<std::shared_ptr<ion_heap>> ion_heaps;
+
     std::vector<ulong> get_ion_heaps_by_internal_dev();
     std::vector<ulong> get_ion_heaps_by_heaps();
     std::vector<ulong> get_heaps() override;
@@ -58,6 +55,9 @@ public:
     void parser_ion_page_pool(ulong addr);
     void parser_ion_msm_page_pool(ulong addr);
     void print_heap(std::string name);
+
+public:
+    IonHeap(std::shared_ptr<Dmabuf> dmabuf);
 };
 
 #endif // ION_HEAP_DEFS_H_

--- a/memory/iomem.cpp
+++ b/memory/iomem.cpp
@@ -42,7 +42,7 @@ void IoMem::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-IoMem::IoMem(){
+void IoMem::init_offset(void) {
     field_init(resource,start);
     field_init(resource,end);
     field_init(resource,name);
@@ -51,6 +51,9 @@ IoMem::IoMem(){
     field_init(resource,sibling);
     field_init(resource,child);
     struct_init(resource);
+}
+
+void IoMem::init_command(void) {
     cmd_name = "iomem";
     help_str_list={
         "iomem",                        /* command name */
@@ -69,23 +72,29 @@ IoMem::IoMem(){
         "        0x1880000-0x18de1ff  376.50Kb   : 1880000.interconnect interconnect@1880000",
         "\n",
     };
-    initialize();
 }
 
+IoMem::IoMem(){}
+
 void IoMem::print_iomem(std::vector<std::shared_ptr<resource>>& res_list,int level){
+    std::ostringstream oss;
     for (const auto& res_ptr : res_list) {
         for (int i = 0; i < level; i++) {
-            fprintf(fp, "\t");
+            oss << "\t";
         }
-        std::ostringstream oss;
         oss << std::left << std::setw(9) << csize((res_ptr->end - res_ptr->start)) << " "
             << "[" << std::hex << res_ptr->start << "~" << res_ptr->end << "] "
-            << res_ptr->name;
+            << res_ptr->name << "\n";
         fprintf(fp, "%s \n",oss.str().c_str());
 
         if(res_ptr->childs.size() > 0){
+            fprintf(fp, "%s", oss.str().c_str());
+            oss.str("");
             print_iomem(res_ptr->childs,(level+1));
         }
+    }
+    if (!oss.str().empty()) {
+        fprintf(fp, "%s", oss.str().c_str());
     }
 }
 

--- a/memory/iomem.h
+++ b/memory/iomem.h
@@ -29,13 +29,18 @@ struct resource {
 };
 
 class IoMem : public ParserPlugin {
-public:
+private:
     std::vector<std::shared_ptr<resource>> iomem_list;
-    IoMem();
-    void cmd_main(void) override;
+
     void parser_iomem();
     void print_iomem(std::vector<std::shared_ptr<resource>>& res_list,int level);
     void parser_resource(ulong addr,std::vector<std::shared_ptr<resource>>& res_list);
+
+public:
+    IoMem();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(IoMem)
 };
 

--- a/memory/memblock.cpp
+++ b/memory/memblock.cpp
@@ -42,7 +42,7 @@ void Memblock::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-Memblock::Memblock(){
+void Memblock::init_offset(void) {
     field_init(memblock,bottom_up);
     field_init(memblock,current_limit);
     field_init(memblock,memory);
@@ -58,6 +58,9 @@ Memblock::Memblock(){
     struct_init(memblock);
     struct_init(memblock_type);
     struct_init(memblock_region);
+}
+
+void Memblock::init_command(void) {
     cmd_name = "memblock";
     help_str_list={
         "memblock",                            /* command name */
@@ -79,8 +82,9 @@ Memblock::Memblock(){
         "      [2]  memblock_region:0xffffffde310dd4d8 range:[0x47fffe80~0x48000000] size:384b       flags:MEMBLOCK_NONE",
         "\n",
     };
-    initialize();
 }
+
+Memblock::Memblock(){}
 
 static std::vector<std::string> flags_str = {
     "MEMBLOCK_NONE",
@@ -171,13 +175,11 @@ void Memblock::print_memblock(){
     fprintf(fp, "%s \n",oss.str().c_str());
     print_memblock_type(&block->memory);
 
-    fprintf(fp, "\n");
     oss.str("");
-
     oss << "memblock_type:" << std::hex << block->reserved.addr
         << " [" << block->reserved.name << "] "
         << "total_size:" << csize(block->reserved.total_size);
-    fprintf(fp, "%s \n",oss.str().c_str());
+    fprintf(fp, "%s \n", oss.str().c_str());
     print_memblock_type(&block->reserved);
 }
 
@@ -188,16 +190,16 @@ void Memblock::print_memblock_type(memblock_type* type){
         tmp << std::hex << (type->regions[i]->base + type->regions[i]->size);
         addr_len = std::max(addr_len,tmp.str().length());
     }
+    std::ostringstream oss;
     for (size_t i = 0; i < type->cnt; ++i) {
-        std::ostringstream oss;
         oss << "  ["
-            << std::setw(5) << std::setfill('0') << i << "]"
+            << std::setw(5) << std::setfill('0') << std::dec << std::right << i << "]"
             << "memblock_region:" << std::hex << std::setfill(' ') << type->regions[i]->addr
             << " range:[" << std::right << std::hex << std::setw(addr_len) << std::setfill('0') << type->regions[i]->base
             << "~" << std::right << std::hex << std::setw(addr_len) << std::setfill('0') << (type->regions[i]->base + type->regions[i]->size) << "]"
             << " size:" << std::left << std::setw(10) << std::setfill(' ') << csize(type->regions[i]->size)
-            << " flags:" << flags_str[type->regions[i]->flags];
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << " flags:" << flags_str[type->regions[i]->flags] << "\n";
     }
+    fprintf(fp, "%s \n", oss.str().c_str());
 }
 #pragma GCC diagnostic pop

--- a/memory/memblock.h
+++ b/memory/memblock.h
@@ -51,16 +51,20 @@ struct memblock {
 };
 
 class Memblock : public ParserPlugin {
-public:
+private:
     std::shared_ptr<memblock> block;
-    Memblock();
 
-    void cmd_main(void) override;
     void parser_memblock();
     void parser_memblock_type(ulong addr,memblock_type* type);
     std::vector<std::shared_ptr<memblock_region>> parser_memblock_region(ulong addr,int cnt);
     void print_memblock();
     void print_memblock_type(memblock_type* type);
+
+public:
+    Memblock();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Memblock)
 };
 

--- a/memory/meminfo.cpp
+++ b/memory/meminfo.cpp
@@ -21,7 +21,7 @@
 
 #ifndef BUILD_TARGET_TOGETHER
 DEFINE_PLUGIN_COMMAND(Meminfo)
-#endif // !BUILD_TARGET_TOGETHER
+#endif
 
 void Meminfo::cmd_main(void) {
     int c;
@@ -49,7 +49,7 @@ void Meminfo::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-Meminfo::Meminfo(){
+void Meminfo::init_offset(void) {
     struct_init(page);
     struct_init(zone);
     field_init(zone, watermark);
@@ -94,6 +94,9 @@ Meminfo::Meminfo(){
         field_init(hstate, order);
         field_init(hstate, nr_huge_pages);
     }
+}
+
+void Meminfo::init_command(void) {
     cmd_name = "meminfo";
     help_str_list={
         "meminfo",                            /* command name */
@@ -155,8 +158,9 @@ Meminfo::Meminfo(){
         "    ... ...",
         "\n",
     };
-    initialize();
 }
+
+Meminfo::Meminfo(){}
 
 void Meminfo::parse_meminfo(void){
     const char* enum_names[] = {
@@ -350,7 +354,7 @@ ulong Meminfo::get_mm_committed_pages(void){
     for (uint cpu = 0; cpu < nr_cpu_ids; ++cpu) {
         if (cpu_online_mask & (1UL << cpu)) {
             ulong per_cpu_offset = read_ulong(g_param["__per_cpu_offset"] + sizeof(ulong)*cpu, "get __per_cpu_offset[cpu]");
-            uint temp = read_uint(g_param["vm_committed_as"] + per_cpu_offset + field_offset(percpu_counter, counters), 
+            uint temp = read_uint(g_param["vm_committed_as"] + per_cpu_offset + field_offset(percpu_counter, counters),
                 "get percpu_counter->counters for specific cpu");
             allowed += temp;
         }

--- a/memory/meminfo.h
+++ b/memory/meminfo.h
@@ -48,13 +48,15 @@ private:
     size_t get_dentry_cache_size();
     size_t get_inode_cache_size();
     ulong get_vmalloc_total(void);
+    void print_vmstat(void);
+    void print_mem_breakdown(void);
+    void print_meminfo(void);
 
 public:
     Meminfo();
     void cmd_main(void) override;
-    void print_vmstat(void);
-    void print_mem_breakdown(void);
-    void print_meminfo(void);
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Meminfo)
 };
 

--- a/memory/reserved.h
+++ b/memory/reserved.h
@@ -35,14 +35,18 @@ struct reserved_mem {
 };
 
 class Reserved : public ParserPlugin {
-public:
+private:
     std::shared_ptr<Devicetree> dts;
     std::vector<std::shared_ptr<reserved_mem>> mem_list;
-    Reserved();
 
-    void cmd_main(void) override;
     void parser_reserved_mem();
     void print_reserved_mem();
+
+public:
+    Reserved();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Reserved)
 };
 

--- a/memory/slub.h
+++ b/memory/slub.h
@@ -138,7 +138,7 @@ struct track { // see __kmem_obj_info in slub.c
 };
 
 class Slub : public ParserPlugin {
-protected:
+private:
     std::vector<std::shared_ptr<kmem_cache>> cache_list;
     std::unordered_map<std::string, std::vector<std::shared_ptr<track>>> alloc_trace_map;
     std::unordered_map<std::string, std::vector<std::shared_ptr<track>>> free_trace_map;
@@ -147,9 +147,6 @@ protected:
     ulong stack_slabs;
     // std::unordered_set<size_t> unique_hash;
 
-public:
-    Slub();
-    void cmd_main(void) override;
     void parser_slab_caches();
     std::vector<std::shared_ptr<kmem_cache_node>> parser_kmem_cache_node(std::shared_ptr<kmem_cache> cache_ptr, ulong node_addr);
     std::vector<std::shared_ptr<kmem_cache_cpu>> parser_kmem_cache_cpu(std::shared_ptr<kmem_cache> cache_ptr, ulong cpu_addr);
@@ -160,7 +157,6 @@ public:
     void print_slab_info(std::shared_ptr<slab> slab_ptr);
     void print_slab_cache_info(std::string addr);
     void print_slab_cache(std::shared_ptr<kmem_cache> cache_ptr);
-
     /* Poison */
     unsigned int get_info_end(std::shared_ptr<kmem_cache> cache_ptr);
     bool freeptr_outside_object(std::shared_ptr<kmem_cache> cache_ptr);
@@ -182,7 +178,6 @@ public:
     void print_slub_poison(ulong kmem_cache_addr = 0);
     int check_object(std::shared_ptr<kmem_cache> cache_ptr, ulong first_page, ulong start_addr, uint8_t val);
     ulong get_free_pointer(std::shared_ptr<kmem_cache> cache_ptr, ulong object_start_addr);
-
     /*Trace*/
     std::string extract_callstack(ulong frames_addr);
     void parser_track_map(std::unordered_map<std::string, std::vector<std::shared_ptr<track>>> map, bool is_free);
@@ -194,6 +189,12 @@ public:
     ulong get_track(std::shared_ptr<kmem_cache> cache_ptr, ulong object_start_addr, uint8_t track_type);
     void parser_obj_track(std::shared_ptr<kmem_cache> cache_ptr, ulong object_start_addr, uint8_t track_type);
     void parser_slab_track(std::shared_ptr<kmem_cache> cache_ptr, std::shared_ptr<slab> slab_ptr);
+
+public:
+    Slub();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Slub)
 };
 

--- a/memory/swap.cpp
+++ b/memory/swap.cpp
@@ -95,13 +95,13 @@ void Swap::print_page_memory(std::string addr){
         fprintf(fp, "please set current task context by command set <pid>\n");
         return;
     }
-    char page_data[page_size];
     ulong uaddr = std::stoul(addr, nullptr, 16);
-    if(!uread_buffer(tc->task,uaddr,page_data,page_size,"read page")){
+    std::vector<char> page_data = uread_memory(tc->task,uaddr, page_size, "read page");
+    if(page_data.size() == 0){
         fprintf(fp, "not mapped page\n");
         return;
     }else{
-        fprintf(fp, "\nprint_page_memory:\n%s \n", hexdump(uaddr, page_data, page_size).c_str());
+        fprintf(fp, "\nprint_page_memory:\n%s \n", hexdump(uaddr, page_data.data(), page_size).c_str());
     }
 }
 

--- a/memory/swap.cpp
+++ b/memory/swap.cpp
@@ -35,10 +35,6 @@ void Swap::cmd_main(void) {
                 cppString.assign(optarg);
                 print_page_memory(cppString);
                 break;
-            case 'd':
-                debug = true;
-                zram_ptr->enable_debug(true);
-                break;
             default:
                 argerrs++;
                 break;
@@ -48,15 +44,13 @@ void Swap::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-Swap::Swap(std::shared_ptr<Zraminfo> zram) : Swapinfo(zram){
-    init_command();
-}
+Swap::Swap(std::shared_ptr<Zraminfo> zram) : Swapinfo(zram){}
 
-Swap::Swap() : Swapinfo(std::make_shared<Zraminfo>()) {
-    init_command();
-}
+Swap::Swap() : Swapinfo(std::make_shared<Zraminfo>()) {}
 
-void Swap::init_command(){
+void Swap::init_offset(void) {}
+
+void Swap::init_command(void){
     cmd_name = "swapinfo";
     help_str_list={
         "swapinfo",                            /* command name */
@@ -86,7 +80,6 @@ void Swap::init_command(){
         "    %s> swapinfo -d",
         "\n",
     };
-    initialize();
 }
 
 void Swap::print_page_memory(std::string addr){
@@ -106,24 +99,26 @@ void Swap::print_page_memory(std::string addr){
 }
 
 void Swap::print_swaps(){
-    std::ostringstream oss_hd;
-    oss_hd << std::left << std::setw(VADDR_PRLEN + 2) << "swap_info_struct" << " "
+    nr_swap = read_int(csymbol_value("nr_swapfiles"),"nr_swapfiles");
+    if (swap_list.size() == 0 && nr_swap > 0){
+        parser_swap_info();
+    }
+    std::ostringstream oss;
+    fprintf(fp, "========================================================================\n");
+    oss << std::left << std::setw(VADDR_PRLEN + 2) << "swap_info_struct" << " "
         << std::left << std::setw(10) << "size" << " "
         << std::left << std::setw(10) << "used" << " "
         << std::left << std::setw(VADDR_PRLEN + 2) << "address_space" << " "
-        << "file";
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
+        << "file" << "\n";
 
-    fprintf(fp, "========================================================================\n");
     for (const auto& swap_ptr : swap_list) {
-        std::ostringstream oss;
         oss << std::left << std::setw(VADDR_PRLEN + 2) << std::hex << swap_ptr->addr << " "
             << std::left << std::setw(10) << csize(swap_ptr->pages * page_size) << " "
             << std::left << std::setw(10) << csize(swap_ptr->inuse_pages * page_size) << " "
             << std::left << std::setw(VADDR_PRLEN + 2) << std::hex << swap_ptr->swap_space << " "
             << swap_ptr->swap_file;
-        fprintf(fp, "%s \n",oss.str().c_str());
     }
+    fprintf(fp, "%s \n", oss.str().c_str());
     fprintf(fp, "========================================================================\n");
 }
 #pragma GCC diagnostic pop

--- a/memory/swap.h
+++ b/memory/swap.h
@@ -19,13 +19,16 @@
 #include "swapinfo.h"
 
 class Swap : public Swapinfo {
+private:
+    void print_swaps();
+    void print_page_memory(std::string addr);
+
 public:
     Swap();
     Swap(std::shared_ptr<Zraminfo> zram);
     void cmd_main(void) override;
-    void init_command();
-    void print_swaps();
-    void print_page_memory(std::string addr);
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Swap)
 };
 

--- a/memory/swapinfo.cpp
+++ b/memory/swapinfo.cpp
@@ -18,25 +18,22 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
-void Swapinfo::cmd_main(void) {
-
-}
+void Swapinfo::cmd_main(void) {}
 
 Swapinfo::Swapinfo(std::shared_ptr<Zraminfo> zram): zram_ptr(zram){
-    init_command();
+    init_offset();
 }
 
 Swapinfo::Swapinfo(){
     zram_ptr = std::make_shared<Zraminfo>();
-    init_command();
-    //print_table();
+    init_offset();
 }
 
 bool Swapinfo::is_zram_enable(){
     return zram_ptr->is_zram_enable();
 }
 
-void Swapinfo::init_command(){
+void Swapinfo::init_offset(void) {
     field_init(swap_info_struct,pages);
     field_init(swap_info_struct,inuse_pages);
     field_init(swap_info_struct,swap_file);
@@ -57,9 +54,9 @@ void Swapinfo::init_command(){
     struct_init(address_space);
 }
 
-Swapinfo::~Swapinfo(){
+void Swapinfo::init_command(void) {}
 
-}
+Swapinfo::~Swapinfo(){}
 
 ulonglong Swapinfo::pte_handle_index(std::shared_ptr<swap_info> swap_ptr, ulonglong pte_val){
     ulong swp_offset = 0;

--- a/memory/swapinfo.cpp
+++ b/memory/swapinfo.cpp
@@ -55,7 +55,6 @@ void Swapinfo::init_command(){
     field_init(address_space,i_pages);
     field_init(address_space,page_tree);
     struct_init(address_space);
-    parser_swap_info();
 }
 
 Swapinfo::~Swapinfo(){
@@ -146,122 +145,102 @@ ulong Swapinfo::lookup_swap_cache(ulonglong pte_val){
 
 std::string Swapinfo::uread_cstring(ulonglong task_addr,ulonglong uvaddr,int len, const std::string& note){
     std::string res;
-    char* buf = uread_memory(task_addr,uvaddr,len, note);
-    if(buf != nullptr){
-        res = buf;
-        std::free(buf);
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,len, note);
+    if(buf.size() == 0){
+        res.assign(buf.begin(), buf.end());
+        return res;
     }
     return res;
 }
 
 bool Swapinfo::uread_bool(ulonglong task_addr,ulonglong uvaddr,const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,sizeof(bool), note);
-    if(buf == nullptr){
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,sizeof(bool), note);
+    if(buf.size() == 0){
         return false;
     }
-    bool res = BOOL(buf);
-    std::free(buf);
+    bool res = BOOL(buf.data());
     return res;
 }
 
 int Swapinfo::uread_int(ulonglong task_addr,ulonglong uvaddr,const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,sizeof(int), note);
-    if(buf == nullptr){
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,sizeof(int), note);
+    if(buf.size() == 0){
         return 0;
     }
-    int res = INT(buf);
-    std::free(buf);
+    int res = INT(buf.data());
     return res;
 }
 
 uint Swapinfo::uread_uint(ulonglong task_addr,ulonglong uvaddr,const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,sizeof(uint), note);
-    if(buf == nullptr){
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,sizeof(uint), note);
+    if(buf.size() == 0){
         return 0;
     }
-    uint res = UINT(buf);
-    std::free(buf);
+    uint res = UINT(buf.data());
     return res;
 }
 
 long Swapinfo::uread_long(ulonglong task_addr,ulonglong uvaddr,const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,sizeof(long), note);
-    if(buf == nullptr){
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,sizeof(long), note);
+    if(buf.size() == 0){
         return 0;
     }
-    long res = LONG(buf);
-    std::free(buf);
+    long res = LONG(buf.data());
     return res;
 }
 
 ulong Swapinfo::uread_ulong(ulonglong task_addr,ulonglong uvaddr,const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,sizeof(ulong), note);
-    if(buf == nullptr){
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,sizeof(ulong), note);
+    if(buf.size() == 0){
         return 0;
     }
-    ulong res = ULONG(buf);
-    std::free(buf);
+    ulong res = ULONG(buf.data());
     return res;
 }
 
 ulonglong Swapinfo::uread_ulonglong(ulonglong task_addr,ulonglong uvaddr,const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,sizeof(ulonglong), note);
-    if(buf == nullptr){
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,sizeof(ulonglong), note);
+    if(buf.size() == 0){
         return 0;
     }
-    ulonglong res = ULONGLONG(buf);
-    std::free(buf);
+    ulonglong res = ULONGLONG(buf.data());
     return res;
 }
 
 ushort Swapinfo::uread_ushort(ulonglong task_addr,ulonglong uvaddr,const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,sizeof(ushort), note);
-    if(buf == nullptr){
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,sizeof(ushort), note);
+    if(buf.size() == 0){
         return 0;
     }
-    ushort res = USHORT(buf);
-    std::free(buf);
+    ushort res = USHORT(buf.data());
     return res;
 }
 
 short Swapinfo::uread_short(ulonglong task_addr,ulonglong uvaddr,const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,sizeof(short), note);
-    if(buf == nullptr){
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,sizeof(short), note);
+    if(buf.size() == 0){
         return 0;
     }
-    short res = SHORT(buf);
-    std::free(buf);
+    short res = SHORT(buf.data());
     return res;
 }
 
 ulong Swapinfo::uread_pointer(ulonglong task_addr,ulonglong uvaddr,const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,sizeof(void *), note);
-    if(buf == nullptr){
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,sizeof(void *), note);
+    if(buf.size() == 0){
         return 0;
     }
-    ulong res = (ulong)VOID_PTR(buf);
-    std::free(buf);
+    ulong res = (ulong)VOID_PTR(buf.data());
     return res;
 }
 
 unsigned char Swapinfo::uread_byte(ulonglong task_addr,ulonglong uvaddr,const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,1, note);
-    if(buf == nullptr){
+    std::vector<char> buf = uread_memory(task_addr,uvaddr,1, note);
+    if(buf.size() == 0){
         return 0;
     }
-    unsigned char res = UCHAR(buf);
-    std::free(buf);
+    unsigned char res = UCHAR(buf.data());
     return res;
-}
-
-bool Swapinfo::uread_buffer(ulonglong task_addr,ulonglong uvaddr,char* result, int len, const std::string& note){
-    char* buf = uread_memory(task_addr,uvaddr,len, note);
-    if(buf == nullptr){
-        return false;
-    }
-    memcpy(result,buf,len);
-    std::free(buf);
-    return true;
 }
 
 // read data across many pages
@@ -270,18 +249,17 @@ bool Swapinfo::uread_buffer(ulonglong task_addr,ulonglong uvaddr,char* result, i
 // -----------------------------------------------------------------
 //                  ^                              ^
 //                  |                              |
-char* Swapinfo::uread_memory(ulonglong task_addr,ulonglong uvaddr,int len, const std::string& note){
+std::vector<char> Swapinfo::uread_memory(ulonglong task_addr,ulonglong uvaddr,int len, const std::string& note){
     int remain = len;
-    char* result = (char*)std::malloc(len);
+    std::vector<char> result(len);
     // ulong orig_uvaddr = uvaddr;
-    BZERO(result, len);
     while(remain > 0){
         // read one page
         char* buf_page = do_swap_page(task_addr,uvaddr);
         int offset_in_page = (uvaddr & ~page_mask);
         int read_len = std::min(remain, static_cast<int>(page_size) - offset_in_page);
         if(buf_page != nullptr){
-            memcpy(result + (len - remain), buf_page + offset_in_page, read_len);
+            memcpy(result.data() + (len - remain), buf_page + offset_in_page, read_len);
             FREEBUF(buf_page);
         }
         remain -= read_len;
@@ -306,6 +284,10 @@ bool Swapinfo::is_swap_pte(ulong pte){
 }
 
 char* Swapinfo::do_swap_page(ulonglong task_addr,ulonglong uvaddr){
+    nr_swap = read_int(csymbol_value("nr_swapfiles"),"nr_swapfiles");
+    if (swap_list.size() == 0 && nr_swap > 0){
+        parser_swap_info();
+    }
     physaddr_t paddr = 0;
     // struct task_context *tc = CURRENT_CONTEXT();
     // if(tc->task != task_addr){

--- a/memory/swapinfo.h
+++ b/memory/swapinfo.h
@@ -38,7 +38,6 @@ struct swap_info {
 class Swapinfo : public ParserPlugin {
 private:
     int nr_swap;
-    char* uread_memory(ulonglong task_addr,ulonglong uvaddr,int len, const std::string& note);
     char* do_swap_page(ulonglong task_addr,ulonglong uvaddr);
     void parser_swap_info();
     std::shared_ptr<swap_info> get_swap_info(ulonglong pte_val);
@@ -68,8 +67,8 @@ public:
     ~Swapinfo();
     void init_command();
     void cmd_main(void) override;
-    bool uread_buffer(ulonglong task_addr, ulonglong uvaddr, char *result, int len, const std::string &note);
     std::string uread_cstring(ulonglong task_addr,ulonglong uvaddr,int len, const std::string& note);
+    std::vector<char> uread_memory(ulonglong task_addr,ulonglong uvaddr,int len, const std::string& note);
     bool is_swap_pte(ulong pte);
 };
 

--- a/memory/swapinfo.h
+++ b/memory/swapinfo.h
@@ -37,9 +37,10 @@ struct swap_info {
 
 class Swapinfo : public ParserPlugin {
 private:
-    int nr_swap;
+    bool debug = false;
+    std::shared_ptr<Zraminfo> zram_ptr;
+
     char* do_swap_page(ulonglong task_addr,ulonglong uvaddr);
-    void parser_swap_info();
     std::shared_ptr<swap_info> get_swap_info(ulonglong pte_val);
     ulong get_zram_addr(std::shared_ptr<swap_info> swap_ptr, ulonglong pte_val);
     ulong lookup_swap_cache(ulonglong pte_val);
@@ -55,21 +56,21 @@ private:
     unsigned char uread_byte(ulonglong task_addr,ulonglong uvaddr,const std::string& note);
     ulonglong pte_handle_index(std::shared_ptr<swap_info> swap_ptr, ulonglong pte_val);
 
-protected:
-    bool debug = false;
-    std::shared_ptr<Zraminfo> zram_ptr;
-    std::vector<std::shared_ptr<swap_info>> swap_list;
-
 public:
+    std::vector<std::shared_ptr<swap_info>> swap_list;
+    int nr_swap;
+
     Swapinfo();
     bool is_zram_enable();
     Swapinfo(std::shared_ptr<Zraminfo> zram);
     ~Swapinfo();
-    void init_command();
     void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     std::string uread_cstring(ulonglong task_addr,ulonglong uvaddr,int len, const std::string& note);
     std::vector<char> uread_memory(ulonglong task_addr,ulonglong uvaddr,int len, const std::string& note);
     bool is_swap_pte(ulong pte);
+    void parser_swap_info();
 };
 
 #endif // SWAP_INFO_DEFS_H_

--- a/memory/vmalloc.h
+++ b/memory/vmalloc.h
@@ -44,21 +44,17 @@ struct vmalloc_info {
 };
 
 class Vmalloc : public ParserPlugin {
-public:
+private:
     static const int VM_IOREMAP =0x00000001;
     static const int VM_ALLOC =0x00000002;
     static const int VM_MAP = 0x00000004;
     static const int VM_USERMAP =0x00000008;
     static const int VM_VPAGES =0x00000010;
     static const int VM_UNLIST =0x00000020;
-
     std::vector<std::shared_ptr<vmap_area>> area_list;
-    Vmalloc();
 
     void parser_vmap_nodes();
     void parser_vmap_area(ulong addr);
-
-    void cmd_main(void) override;
     void parser_vmap_area_list();
     void print_vmap_area_list();
     void print_vmap_area();
@@ -68,6 +64,12 @@ public:
     void print_summary_type();
     void print_vm_info_caller(std::string func);
     void print_vm_info_type(std::string type);
+
+public:
+    Vmalloc();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Vmalloc)
 };
 

--- a/memory/zram.h
+++ b/memory/zram.h
@@ -23,9 +23,7 @@ private:
     static const int PRINT_SIZE_CLASS = 0x0001;
     static const int PRINT_ZSPAGE = 0x0002;
     static const int PRINT_PAGE = 0x0004;
-public:
-    Zram();
-    void cmd_main(void) override;
+
     void print_zrams();
     void print_zram_full_info(std::string zram_addr);
     void print_mem_pool(std::string zram_addr);
@@ -36,6 +34,12 @@ public:
     void print_size_class_obj(std::shared_ptr<size_class> class_ptr);
     void print_zspage_obj(std::shared_ptr<zpage> zspage_ptr);
     void print_page_obj(std::shared_ptr<pageinfo> page_ptr);
+
+public:
+    Zram();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Zram)
 };
 

--- a/memory/zraminfo.cpp
+++ b/memory/zraminfo.cpp
@@ -18,9 +18,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
-void Zraminfo::cmd_main(void) {
+void Zraminfo::cmd_main(void) {}
 
-}
+void Zraminfo::init_command(void) {}
 
 Zraminfo::Zraminfo(){
     init_offset();
@@ -36,7 +36,7 @@ Zraminfo::Zraminfo(){
     group_cnt = field_size(size_class,fullness_list)/sizeof(struct kernel_list_head);
 }
 
-void Zraminfo::init_offset(){
+void Zraminfo::init_offset(void) {
     field_init(zram,table);
     field_init(zram,mem_pool);
     field_init(zram,comp);
@@ -598,9 +598,4 @@ std::shared_ptr<zram> Zraminfo::parser_zram(ulong addr){
     zram_list.push_back(zram_ptr);
     return zram_ptr;
 }
-
-void Zraminfo::enable_debug(bool on){
-    debug = true;
-}
-
 #pragma GCC diagnostic pop

--- a/memory/zraminfo.h
+++ b/memory/zraminfo.h
@@ -127,34 +127,22 @@ enum zs_stat_type {
 };
 
 class Zraminfo : public ParserPlugin {
-protected:
+private:
     bool debug = false;
-public:
-    std::vector<std::shared_ptr<zram>> zram_list;
-    Zraminfo();
-
-    int group_cnt;
     int ZRAM_FLAG_SHIFT;
     int ZRAM_FLAG_SAME_BIT;
     int ZRAM_FLAG_WB_BIT;
     int ZRAM_COMP_PRIORITY_BIT1;
     int ZRAM_COMP_PRIORITY_MASK;
 
-    void cmd_main(void) override;
-    bool is_zram_enable();
-    void parser_zrams();
-    void init_offset();
     std::shared_ptr<zram> parser_zram(ulong addr);
-    void enable_debug(bool on);
     std::shared_ptr<zs_pool> parser_mem_pool(ulong addr);
     std::shared_ptr<size_class> parser_size_class(ulong addr);
-    void parser_zpage(std::shared_ptr<size_class> class_ptr);
     std::shared_ptr<zpage> parser_zpage(ulong addr,std::shared_ptr<size_class> class_ptr);
     void parser_pages(ulong first_page,std::shared_ptr<size_class> class_ptr,std::shared_ptr<zpage> page_ptr);
     void parser_obj(ulong page_addr,std::shared_ptr<size_class> class_ptr,std::shared_ptr<zpage> page_ptr);
     std::shared_ptr<zobj> parser_obj(int obj_id, ulong handle_addr,physaddr_t start,physaddr_t end);
     void handle_to_location(ulong handle, ulong* pfn, int* obj_idx);
-    char* read_zram_page(ulong zram_addr, ulonglong index);
     bool read_table_entry(std::shared_ptr<zram> zram_ptr, ulonglong index, struct zram_table_entry* entry);
     char* read_object(std::shared_ptr<zram> zram_ptr,struct zram_table_entry entry,int& read_len, bool& huge_obj);
     bool get_zspage(ulong page,struct zspage* zp);
@@ -162,6 +150,19 @@ public:
     int decompress(std::string comp_name,char* source, char* dest,int compressedSize, int maxDecompressedSize);
     int lzo1x_decompress(char *source, char *dest, int compressedSize, int maxDecompressedSize);
     int lz4_decompress(char *source, char *dest, int compressedSize, int maxDecompressedSize);
+
+public:
+    std::vector<std::shared_ptr<zram>> zram_list;
+    int group_cnt;
+
+    Zraminfo();
+    void parser_zrams();
+    void parser_zpage(std::shared_ptr<size_class> class_ptr);
+    char* read_zram_page(ulong zram_addr, ulonglong index);
+    bool is_zram_enable();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
 };
 
 #endif // ZRAM_DRV_DEFS_H_

--- a/pagecache/pageinfo.cpp
+++ b/pagecache/pageinfo.cpp
@@ -83,32 +83,32 @@ void Pageinfo::print_file_pages(){
         return a->nrpages > b->nrpages;
     });
     fprintf(fp, "===============================================\n");
-    std::ostringstream oss_hd;
-    oss_hd  << std::left << std::setw(VADDR_PRLEN)  << "inode" << " "
+    std::ostringstream oss;
+    oss  << std::left << std::setw(VADDR_PRLEN)  << "inode" << " "
             << std::left << std::setw(VADDR_PRLEN)  << "address_space" << " "
             << std::left << std::setw(8)            << "nrpages" << " "
             << std::left << std::setw(10)           << "size" << " "
-            << std::left << "Path";
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
+            << std::left << "Path"
+            << "\n";
     for (const auto& file_ptr : cache_list) {
-        std::ostringstream oss;
         oss << std::left << std::hex  << std::setw(VADDR_PRLEN) << file_ptr->inode << " "
             << std::left << std::hex  << std::setw(VADDR_PRLEN) << file_ptr->i_mapping << " "
             << std::left << std::dec  << std::setw(8)           << file_ptr->nrpages << " "
             << std::left << std::dec  << std::setw(10)          << csize(file_ptr->nrpages * page_size) << " "
-            << std::left << file_ptr->name;
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << std::left << file_ptr->name
+            << "\n";
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
-void Pageinfo::init_offset(){
+void Pageinfo::init_offset(void) {
     field_init(inode,i_mapping);
     field_init(inode,i_dentry);
     field_init(inode,i_sb);
     field_init(dentry,d_u);
 }
 
-Pageinfo::Pageinfo(){
+void Pageinfo::init_command(void) {
     cmd_name = "cache";
     help_str_list={
         "cache",                            /* command name */
@@ -146,8 +146,8 @@ Pageinfo::Pageinfo(){
         "    page:0xfffffffe0007f4c0  paddr:0x41fd3000",
         "\n",
     };
-    initialize();
-    init_offset();
 }
+
+Pageinfo::Pageinfo(){}
 
 #pragma GCC diagnostic pop

--- a/pagecache/pageinfo.h
+++ b/pagecache/pageinfo.h
@@ -28,16 +28,18 @@ struct FileCache {
 class Pageinfo : public ParserPlugin {
 private:
     std::vector<std::shared_ptr<FileCache>> cache_list;
-    
-public:
-    Pageinfo();
+
     bool page_buddy(ulong page_addr);
     int page_count(ulong page_addr);
     void parser_file_pages();
     void print_file_pages();
-    void init_offset();
-    void cmd_main(void) override;
     void print_anon_pages();
+
+public:
+    Pageinfo();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Pageinfo)
 };
 

--- a/pageowner/pageowner.cpp
+++ b/pageowner/pageowner.cpp
@@ -84,8 +84,7 @@ bool Pageowner::is_enable_pageowner(){
     return true;
 }
 
-Pageowner::Pageowner(){
-    debug = false;
+void Pageowner::init_offset(void) {
     field_init(page_owner,order);
     field_init(page_owner,last_migrate_reason);
     field_init(page_owner,gfp_mask);
@@ -116,6 +115,9 @@ Pageowner::Pageowner(){
     field_init(stack_record,handle);
     field_init(stack_record,entries);
     struct_init(stack_record);
+}
+
+void Pageowner::init_command(void) {
     cmd_name = "pageowner";
     help_str_list={
         "pageowner",                            /* command name */
@@ -328,8 +330,9 @@ Pageowner::Pageowner(){
         "        2023     ndroid.systemui      4195       16.64MB",
         "\n",
     };
-    initialize();
 }
+
+Pageowner::Pageowner(){}
 
 void Pageowner::print_page_owner(std::string addr,int flags){
     ulonglong number = std::stoul(addr, nullptr, 16);
@@ -390,15 +393,15 @@ void Pageowner::print_page_owner(std::shared_ptr<page_owner> owner_ptr, bool is_
 }
 
 void Pageowner::print_memory_info(){
-    std::ostringstream oss_hd;
-    oss_hd << std::left << std::setw(8) << "PID" << " "
+    std::ostringstream oss;
+    oss << std::left << std::setw(8) << "PID" << " "
         << std::left << std::setw(20) << "Comm" << " "
         << std::left << std::setw(10) << "Times" << " "
         << std::left << std::setw(10) << "Size";
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
+    fprintf(fp, "%s \n", oss.str().c_str());
 
     ulong page_owner_size = page_owner_page_list.size()*page_size;
-    std::ostringstream oss;
+    oss.str("");
     oss << std::left << std::setw(8) << "" << " "
         << std::left << std::setw(20) << "page_owner" << " "
         << std::left << std::setw(10) << "" << " "
@@ -411,7 +414,7 @@ void Pageowner::print_memory_info(){
     << std::left << std::setw(20) << "stack_record" << " "
     << std::left << std::setw(10) << "" << " "
     << std::left << std::setw(10) << csize(stack_record_size);
-    fprintf(fp, "%s \n",oss.str().c_str());
+    fprintf(fp, "%s \n", oss.str().c_str());
 
     std::unordered_map<size_t, std::shared_ptr<process_info>> process_map; //<pid,process_info>
     for (const auto& pair : owner_map) {
@@ -443,7 +446,7 @@ void Pageowner::print_memory_info(){
             name = std::string(tc->comm);
         }
         std::shared_ptr<process_info> proc_ptr = process_vec[i].second;
-        std::ostringstream oss;
+        oss.str("");
         oss << std::left << std::setw(8) << pid << " "
             << std::left << std::setw(20) << name << " "
             << std::left << std::setw(10) << proc_ptr->total_cnt << " "
@@ -516,12 +519,12 @@ void Pageowner::print_total_size_by_pid(std::unordered_map<size_t, std::shared_p
         return a.second->total_cnt > b.second->total_cnt;
     });
     fprintf(fp, "      -------------------------------------------------\n");
-    std::ostringstream oss_hd;
-    oss_hd << std::left << "      " << std::setw(8) << "PID" << " "
+    std::ostringstream oss;
+    oss << std::left << "      " << std::setw(8) << "PID" << " "
         << std::left << std::setw(20) << "Comm" << " "
         << std::left << std::setw(10) << "Times" << " "
         << std::left << std::setw(10) << "Size";
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
+    fprintf(fp, "%s \n", oss.str().c_str());
     size_t print_cnt = 20; //only print top 20
     for (size_t i = 0; i < process_vec.size() && i < print_cnt; i++){
         size_t pid = process_vec[i].first;
@@ -531,12 +534,12 @@ void Pageowner::print_total_size_by_pid(std::unordered_map<size_t, std::shared_p
             name = std::string(tc->comm);
         }
         std::shared_ptr<process_info> proc_ptr = process_vec[i].second;
-        std::ostringstream oss;
+        oss.str("");
         oss << std::left << "      " << std::setw(8) << pid << " "
             << std::left << std::setw(20) << name << " "
             << std::left << std::setw(10) << proc_ptr->total_cnt << " "
             << std::left << std::setw(10) << csize(proc_ptr->total_size);
-        fprintf(fp, "%s \n",oss.str().c_str());
+        fprintf(fp, "%s \n", oss.str().c_str());
     }
 }
 

--- a/pageowner/pageowner.h
+++ b/pageowner/pageowner.h
@@ -76,13 +76,7 @@ private:
     static const int INPUT_PFN = 0x0001;
     static const int INPUT_PYHS = 0x0002;
     static const int INPUT_PAGE = 0x0004;
-public:
-    std::unordered_map<size_t, std::shared_ptr<page_owner>> owner_map; //<pfn, page_owner>
-    std::unordered_map<unsigned int, std::shared_ptr<stack_info>> handle_map; //<handle,stack_info>
-    std::set<ulong> page_owner_page_list;
-    std::set<ulong> stack_record_page_list;
-    Pageowner();
-    bool debug;
+    bool debug = false;
     int page_ext_size;
     int depot_index;
     ulong stack_slabs;
@@ -91,7 +85,11 @@ public:
     size_t ops_offset;
     long PAGE_EXT_OWNER;
     long PAGE_EXT_OWNER_ALLOCATED;
-    void cmd_main(void) override;
+    std::unordered_map<size_t, std::shared_ptr<page_owner>> owner_map; //<pfn, page_owner>
+    std::unordered_map<unsigned int, std::shared_ptr<stack_info>> handle_map; //<handle,stack_info>
+    std::set<ulong> page_owner_page_list;
+    std::set<ulong> stack_record_page_list;
+
     bool is_enable_pageowner();
     void parser_all_pageowners();
     std::shared_ptr<page_owner> parser_page_owner(ulong addr);
@@ -107,6 +105,12 @@ public:
     void print_total_size_by_handle();
     void print_total_size_by_pid(std::unordered_map<size_t, std::shared_ptr<page_owner>> owner_list);
     void print_memory_info();
+
+public:
+    Pageowner();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Pageowner)
 };
 

--- a/partition/filesystem.h
+++ b/partition/filesystem.h
@@ -35,6 +35,8 @@ public:
     std::vector<std::shared_ptr<Mount>> childs;
 
     void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     virtual void statfs(int width);
 };
 
@@ -42,27 +44,37 @@ class F2fs: public Mount {
 public:
     F2fs();
     void statfs(int width) override;
+    void init_offset(void) override;
+    void init_command(void) override;
 };
 
 class Ext4 : public Mount {
 public:
     Ext4();
     void statfs(int width) override;
+    void init_offset(void) override;
+    void init_command(void) override;
+
+private:
     long long percpu_counter_sum(ulong addr);
 };
 
 class FileSystem : public ParserPlugin {
-public:
+private:
     std::vector<std::shared_ptr<Mount>> mount_list;
     std::unordered_map<size_t, std::shared_ptr<Mount>> sb_list;
-    FileSystem();
 
-    void cmd_main(void) override;
     std::shared_ptr<Mount> parser_mount(ulong mount_addr);
     void print_mount_tree(std::vector<std::shared_ptr<Mount>>& mnt_list,int level);
     void print_partition_size(void);
     void parser_mount_tree(void);
     void parser_mount_tree(ulong mount_addr,std::vector<std::shared_ptr<Mount>>& mnt_list);
+
+public:
+    FileSystem();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(FileSystem)
 };
 

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -1538,4 +1538,8 @@ void ParserPlugin::uwind_task_back_trace(int pid, ulong x30){
     fprintf(fp, "\n");
 #endif
 }
+
+cmd_func_t ParserPlugin::get_wrapper_func() {
+    return nullptr;
+}
 #pragma GCC diagnostic pop

--- a/procrank/procrank.cpp
+++ b/procrank/procrank.cpp
@@ -43,24 +43,22 @@ void Procrank::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-Procrank::Procrank(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){
-    init_command();
-}
+void Procrank::init_offset(void) {}
+
+Procrank::Procrank(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){}
 
 Procrank::Procrank(){
-    init_command();
     swap_ptr = std::make_unique<Swapinfo>();
-    //print_table();
 }
 
-void Procrank::init_command(){
+void Procrank::init_command(void){
     cmd_name = "procrank";
     help_str_list={
         "procrank",                            /* command name */
         "dump process memory information",        /* short description */
         "-a \n"
             "  This command dumps the process info. sorted by rss",
-        "-c \n"
+        "  procrank -c \n"
             "  This command dumps the process cmdline.",
         "\n",
         "EXAMPLES",
@@ -77,8 +75,6 @@ void Procrank::init_command(){
         "    1        init                 /system/bin/init",
         "\n",
     };
-    initialize();
-    //print_table();
 }
 
 void Procrank::parser_process_memory() {
@@ -121,34 +117,32 @@ void Procrank::parser_process_memory() {
             return a->rss > b->rss;
         });
     }
-    std::ostringstream oss_hd;
-    oss_hd << std::left << std::setw(8) << "PID" << " "
+    std::ostringstream oss;
+    oss << std::left << std::setw(8) << "PID" << " "
         << std::left << std::setw(10) << "Vss" << " "
         << std::left << std::setw(10) << "Rss" << " "
         << std::left << std::setw(10) << "Pss" << " "
         << std::left << std::setw(10) << "Uss" << " "
         << std::left << std::setw(10) << "Swap" << " "
-        << "Comm";
-    fprintf(fp, "%s \n",oss_hd.str().c_str());
+        << "Comm" << "\n";
     for (const auto& p : procrank_list) {
-        std::ostringstream oss;
         oss << std::left << std::setw(8) << p->pid << " "
             << std::left << std::setw(10) << csize(p->vss) << " "
             << std::left << std::setw(10) << csize(p->rss) << " "
             << std::left << std::setw(10) << csize(p->pss) << " "
             << std::left << std::setw(10) << csize(p->uss) << " "
             << std::left << std::setw(10) << csize(p->swap) << " "
-            << p->cmdline;
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << p->cmdline
+            << "\n";
     }
-    std::ostringstream oss_total;
-    oss_total << std::left << std::setw(8) << "Total" << " "
+    oss << std::left << std::setw(8) << "Total" << " "
         << std::left << std::setw(10) << csize(total_vss) << " "
         << std::left << std::setw(10) << csize(total_rss) << " "
         << std::left << std::setw(10) << csize(total_pss) << " "
         << std::left << std::setw(10) << csize(total_uss) << " "
-        << std::left << std::setw(10) << csize(total_swap);
-    fprintf(fp, "%s\n", oss_total.str().c_str());
+        << std::left << std::setw(10) << csize(total_swap)
+        << "\n";
+    fprintf(fp, "%s\n", oss.str().c_str());
 }
 
 std::shared_ptr<procrank> Procrank::parser_vma(std::shared_ptr<vma_struct> vma_ptr) {
@@ -185,8 +179,8 @@ std::shared_ptr<procrank> Procrank::parser_vma(std::shared_ptr<vma_struct> vma_p
 }
 
 void Procrank::parser_process_name() {
-    std::ostringstream oss_hd;
-    oss_hd << std::left << std::setw(8) << "PID" << " "
+    std::ostringstream oss;
+    oss << std::left << std::setw(8) << "PID" << " "
            << std::left << std::setw(20) << "Comm" << " "
            << std::left << std::setw(10) << "Cmdline" << "\n";
     for(ulong task_addr: for_each_process()){
@@ -201,12 +195,12 @@ void Procrank::parser_process_name() {
         } else {
             cmdline = task_ptr->read_start_args();
         }
-        oss_hd << std::left << std::setw(8) << tc->pid << " "
+        oss << std::left << std::setw(8) << tc->pid << " "
                << std::left << std::setw(20) << tc->comm << " "
                << std::left << std::setw(10) << cmdline << "\n";
         task_ptr.reset();
     }
-    fprintf(fp, "%s \n", oss_hd.str().c_str());
+    fprintf(fp, "%s \n", oss.str().c_str());
 }
 
 #pragma GCC diagnostic pop

--- a/procrank/procrank.h
+++ b/procrank/procrank.h
@@ -31,21 +31,21 @@ struct procrank{
 };
 
 class Procrank : public ParserPlugin {
-private:
-    std::shared_ptr<UTask> task_ptr;
-
 public:
     Procrank();
     Procrank(std::shared_ptr<Swapinfo> swap);
-    void init_command();
     void cmd_main(void) override;
-    void parser_process_memory();
-    void parser_process_name();
-    std::shared_ptr<procrank> parser_vma(std::shared_ptr<vma_struct> vma_ptr);
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Procrank)
 
 private:
     std::shared_ptr<Swapinfo> swap_ptr;
     std::vector<std::shared_ptr<procrank>> procrank_list;
+    std::shared_ptr<UTask> task_ptr;
+
+    std::shared_ptr<procrank> parser_vma(std::shared_ptr<vma_struct> vma_ptr);
+    void parser_process_memory();
+    void parser_process_name();
 };
 #endif // PROCRANK_DEFS_H_

--- a/property/prop.cpp
+++ b/property/prop.cpp
@@ -83,15 +83,13 @@ void Prop::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-Prop::Prop(std::shared_ptr<Swapinfo> swap) : PropInfo(swap){
-    init_command();
-}
+void Prop::init_offset(void) {}
 
-Prop::Prop() : PropInfo(std::make_shared<Swapinfo>()) {
-    init_command();
-}
+Prop::Prop(std::shared_ptr<Swapinfo> swap) : PropInfo(swap){}
 
-void Prop::init_command(){
+Prop::Prop() : PropInfo(std::make_shared<Swapinfo>()) {}
+
+void Prop::init_command(void){
     cmd_name = "getprop";
     help_str_list={
         "getprop",                            /* command name */
@@ -120,7 +118,6 @@ void Prop::init_command(){
         "    encrypted",
         "\n",
     };
-    initialize();
 }
 
 void Prop::print_propertys(){
@@ -129,13 +126,14 @@ void Prop::print_propertys(){
         max_len = std::max(max_len,pair.first.size());
     }
     size_t index = 1;
+    std::ostringstream oss;
     for (const auto& pair : prop_map) {
-        std::ostringstream oss;
         oss << "[" << std::setw(4) << std::setfill('0') << index << "]"
             << std::left << std::setw(max_len) << std::setfill(' ') << pair.first << " "
-            << std::left << pair.second;
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << std::left << pair.second
+            << "\n";
         index++;
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 #pragma GCC diagnostic pop

--- a/property/prop.h
+++ b/property/prop.h
@@ -19,13 +19,15 @@
 #include "property/propinfo.h"
 
 class Prop : public PropInfo {
+private:
+    void print_propertys();
 
 public:
     Prop();
     Prop(std::shared_ptr<Swapinfo> swap);
-    void init_command();
-    void print_propertys();
     void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Prop)
 };
 

--- a/property/propinfo.cpp
+++ b/property/propinfo.cpp
@@ -301,10 +301,10 @@ void PropInfo::parser_prop_by_init(){
             continue;
         }
         prop_files.insert(vma_ptr->name);
-        if(vma_ptr->vm_data == nullptr){
-            vma_ptr->vm_data = (char*)task_ptr->read_vma_data(vma_ptr);
+        if (vma_ptr->vm_data.size() == 0){
+            vma_ptr->vm_data = task_ptr->read_vma_data(vma_ptr);
         }
-        if (!vma_ptr->vm_data){
+        if (vma_ptr->vm_data.size() == 0){
             continue;
         }
         // if(index == 0){
@@ -312,9 +312,9 @@ void PropInfo::parser_prop_by_init(){
         //     fprintf(fp, "System Properties Magic:%#lx, Version:%#lx\n", pa.magic_, pa.version_);
         // }
         // index += 1;
-        prop_bt pb = *reinterpret_cast<prop_bt*>(vma_ptr->vm_data + sizeof(prop_area));
+        prop_bt pb = *reinterpret_cast<prop_bt*>(vma_ptr->vm_data.data() + sizeof(prop_area));
         if(pb.children != 0){
-            for_each_prop(pb.children, vma_ptr->vm_size, vma_ptr->vm_data);
+            for_each_prop(pb.children, vma_ptr->vm_size, vma_ptr->vm_data.data());
         }
     }
 }

--- a/property/propinfo.cpp
+++ b/property/propinfo.cpp
@@ -18,9 +18,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
-void PropInfo::cmd_main(void) {
-
-}
+void PropInfo::cmd_main(void) {}
 
 std::string PropInfo::get_prop(std::string name){
     if (prop_map.size() == 0){
@@ -40,9 +38,9 @@ PropInfo::~PropInfo(){
     swap_ptr = nullptr;
 }
 
-PropInfo::PropInfo(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){
+PropInfo::PropInfo(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){}
 
-}
+void PropInfo::init_command(void) {}
 
 std::string PropInfo::get_symbol_file(std::string name){
     for (const auto& symbol : symbol_list) {
@@ -59,17 +57,17 @@ void PropInfo::print_propertys(){
         max_len = std::max(max_len,pair.first.size());
     }
     size_t index = 1;
+    std::ostringstream oss;
     for (const auto& pair : prop_map) {
-        std::ostringstream oss;
         oss << "[" << std::setw(4) << std::setfill('0') << index << "]"
             << std::left << std::setw(max_len) << std::setfill(' ') << pair.first << " "
-            << std::left << pair.second;
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << std::left << pair.second << "\n";
         index++;
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
-void PropInfo::init_datatype_info(){
+void PropInfo::init_offset(void) {
     field_init(SystemProperties, contexts_);
     field_init(ContextsSerialized, context_nodes_);
     field_init(ContextsSerialized, num_context_nodes_);
@@ -124,7 +122,7 @@ bool PropInfo::parser_propertys(){
     if (symbol_file.empty() || symbol_file == ""){
         return false;
     }
-    init_datatype_info();
+    init_offset();
     size_t pa_size_addr = task_ptr->get_var_addr_by_bss(symbol_file, "pa_size_");
     if (!is_uvaddr(pa_size_addr,tc_init)){
         // fprintf(fp, "pa_size: %#zx is not invaild !\n",pa_size_addr);
@@ -290,7 +288,7 @@ void PropInfo::parser_prop_by_init(){
     if(task_ptr == nullptr){
         task_ptr = std::make_shared<UTask>(swap_ptr, tc_init->task);
     }
-    init_datatype_info();
+    init_offset();
     std::set<std::string> prop_files;
     // size_t index = 0;
     for(const auto& vma_ptr : task_ptr->for_each_file_vma()){

--- a/property/propinfo.h
+++ b/property/propinfo.h
@@ -73,36 +73,42 @@ struct size_list {
 };
 
 class PropInfo : public ParserPlugin {
-protected:
+private:
     bool debug = false;
-    std::shared_ptr<Swapinfo> swap_ptr;
-    std::shared_ptr<UTask> task_ptr;
-
-public:
-    std::unordered_map<std::string, std::string> prop_map; //<name, val>
-    std::vector<symbol> symbol_list = {
-        {"libc.so", ""},
-    };
     struct task_context *tc_init;
     bool is_compat;
     size_t pa_size;
     size_t pa_data_size;
     struct offset_list g_offset;
     struct size_list g_size;
-    PropInfo(std::shared_ptr<Swapinfo> swap);
-    ~PropInfo();
+
     std::string get_symbol_file(std::string name);
-    bool parser_propertys();
     void print_propertys();
-    void init_datatype_info();
     bool parser_prop_area(size_t vaddr);
     void parser_prop_bt(size_t root, size_t prop_bt_addr);
     void parser_prop_info(size_t prop_info_addr);
-    void parser_prop_by_init();
     bool for_each_prop(uint32_t prop_bt_off, size_t vma_len, char *vma_data);
     std::string cleanString(const std::string &str);
-    void cmd_main(void) override;
+
+protected:
+    std::shared_ptr<Swapinfo> swap_ptr;
+    std::shared_ptr<UTask> task_ptr;
+    std::unordered_map<std::string, std::string> prop_map; //<name, val>
+
+public:
+    std::vector<symbol> symbol_list = {
+        {"libc.so", ""},
+    };
+
     std::string get_prop(std::string name);
+    void parser_prop_by_init();
+    bool parser_propertys();
+    PropInfo(std::shared_ptr<Swapinfo> swap);
+    ~PropInfo();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
+
 };
 
 #endif // PROP_INFO_DEFS_H_

--- a/pstore/pstore.cpp
+++ b/pstore/pstore.cpp
@@ -50,7 +50,7 @@ void Pstore::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-Pstore::Pstore(){
+void Pstore::init_offset(void) {
     field_init(ramoops_context,dprzs);
     field_init(ramoops_context,cprz);
     field_init(ramoops_context,fprzs);
@@ -68,6 +68,9 @@ Pstore::Pstore(){
     field_init(persistent_ram_zone,buffer);
     field_init(persistent_ram_buffer,start);
     field_init(persistent_ram_buffer,size);
+}
+
+void Pstore::init_command(void) {
     cmd_name = "pstore";
     help_str_list={
         "pstore",                            /* command name */
@@ -95,8 +98,9 @@ Pstore::Pstore(){
         "    %s> pstore -o",
         "\n",
     };
-    initialize();
 }
+
+Pstore::Pstore(){}
 
 void Pstore::print_ftrace_log(){
     if (!csymbol_exists("oops_cxt")){

--- a/pstore/pstore.h
+++ b/pstore/pstore.h
@@ -46,12 +46,10 @@ private:
         LogLevel::LOG_FATAL,
         LogLevel::LOG_SILENT
     }};
-public:
-    Pstore();
+
     void print_ftrace_log();
     void print_oops_log();
     void print_console_log();
-    void cmd_main(void) override;
     void print_pmsg();
     void extract_pmsg_logs(std::vector<char> &logbuf);
     void parser_system_log(std::string timestamp, uint16_t uid, uint16_t tid, uint16_t pid, char *logbuf, uint16_t msg_len);
@@ -60,6 +58,12 @@ public:
     void appendBuffer(std::vector<char> &destBuf, void *sourceBuf, size_t length);
     std::string formatTime(uint32_t tv_sec, uint32_t tv_nsec);
     std::string getLogLevelChar(LogLevel level);
+
+public:
+    Pstore();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Pstore)
 };
 

--- a/regulator/regulator.h
+++ b/regulator/regulator.h
@@ -48,15 +48,18 @@ struct regulator_dev {
 class Regulator : public ParserPlugin {
 private:
     std::vector<std::shared_ptr<regulator_dev>> regulator_list;
-public:
-    Regulator();
 
     std::vector<ulong> parser_device_list();
     void print_regulator_consumer(std::string reg_name);
     void print_regulator_info();
     void print_regulator_dev();
-    void cmd_main(void) override;
     void parser_regulator_dev();
+
+public:
+    Regulator();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Regulator)
 };
 

--- a/rtb/rtb.cpp
+++ b/rtb/rtb.cpp
@@ -62,7 +62,7 @@ void Rtb::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-void Rtb::init_offset(){
+void Rtb::init_offset(void){
     field_init(msm_rtb_state,msm_rtb_idx);
     field_init(msm_rtb_state,rtb);
     field_init(msm_rtb_state,phys);
@@ -76,8 +76,7 @@ void Rtb::init_offset(){
     struct_init(rtb_idx);
 }
 
-Rtb::Rtb(){
-    init_offset();
+void Rtb::init_command(void) {
     cmd_name = "rtb";
     help_str_list={
         "rtb",            /* command name */
@@ -117,7 +116,10 @@ Rtb::Rtb(){
         "       bc600000-->-----------------",
         "\n",
     };
-    initialize();
+}
+
+Rtb::Rtb(){
+    do_init_offset = false;
 }
 
 bool Rtb::is_enable_rtb(){

--- a/rtb/rtb.h
+++ b/rtb/rtb.h
@@ -56,10 +56,7 @@ struct rtb_state {
 class Rtb : public ParserPlugin {
 private:
     std::shared_ptr<rtb_state> rtb_state_ptr;
-public:
-    Rtb();
-    void cmd_main(void) override;
-    void init_offset();
+
     void parser_rtb_log();
     bool is_enable_rtb();
     void print_rtb_log();
@@ -78,6 +75,12 @@ public:
     std::string get_caller(struct rtb_layout& layout);
     std::string get_fun_name(struct rtb_layout& layout);
     double get_timestamp(struct rtb_layout& layout);
+
+public:
+    Rtb();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Rtb)
 };
 

--- a/surfaceflinger/sf.cpp
+++ b/surfaceflinger/sf.cpp
@@ -46,6 +46,8 @@ void SF::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
+void SF::init_offset(void) {}
+
 /*
 static android::KeyedVector<native_handle const*, android::GraphicBufferAllocator::alloc_rec_t> sAllocList;
 ptype android::SortedVector<android::key_value_pair_t<native_handle const*, android::GraphicBufferAllocator::alloc_rec_t> >
@@ -107,9 +109,9 @@ void SF::parser_gralloc5(){
     SnapAllocCore_addr = task_ptr->uread_pointer(SnapAllocCore_addr);
     // std::unordered_map<SnapHandle *, SnapHandleInternal *> handles_map_ = {};
     ulong core_handles_map = SnapAllocCore_addr + g_offset.SnapAllocCore_handles_map_;
-    std::ostringstream oss_hd;
-    oss_hd << "Imported gralloc5 buffers:\n";
-    oss_hd << std::left << std::setw(40) << "Name"
+    std::ostringstream oss;
+    oss << "Imported gralloc5 buffers:\n";
+    oss << std::left << std::setw(40) << "Name"
         << std::left << std::setw(25) << "W/H"
         << std::left << std::setw(22) << "Dmabuf"
         << std::left << std::setw(12) << "Format"
@@ -130,7 +132,7 @@ void SF::parser_gralloc5(){
             dmabuf = read_pointer(file_addr + field_offset(file,private_data), "private_data");
         }
 
-        oss_hd << std::left << std::setw(40) << name
+        oss << std::left << std::setw(40) << name
             << std::left << std::setw(25)
             << (std::to_string(shi->shp.unaligned_width) + "(" + std::to_string(shi->shp.aligned_width_in_pixels) + ") x " +
                 std::to_string(shi->shp.unaligned_height) + "(" + std::to_string(shi->shp.aligned_height) + ")")
@@ -139,7 +141,7 @@ void SF::parser_gralloc5(){
             << std::left << std::hex << std::showbase << shi->shp.usage
             << std::dec  << std::endl;
     }
-    fprintf(fp, "%s \n", oss_hd.str().c_str());
+    fprintf(fp, "%s \n", oss.str().c_str());
     task_ptr.reset();
 }
 
@@ -169,9 +171,9 @@ void SF::dump_GraphicBufferAllocator(ulong sAllocList_vaddr){
     if(debug){
         fprintf(fp, "sAllocList:%#lx mStorage_addr:%#lx mCount:%zu mFlags:%d mItemSize:%zu\n", sAllocList_vaddr, mStorage_addr, mCount, mFlags, mItemSize);
     }
-    std::ostringstream result;
-    result  << "GraphicBufferAllocator buffers:\n";
-    result  << std::setw(12) << std::right << "Handle" << " | "
+    std::ostringstream oss;
+    oss  << "GraphicBufferAllocator buffers:\n";
+    oss  << std::setw(12) << std::right << "Handle" << " | "
             << std::setw(18) << std::right << "Dmabuf" << " | "
             << std::setw(12) << "Size" << " | "
             << std::setw(18) << "W (Stride) x H" << " | "
@@ -221,7 +223,7 @@ void SF::dump_GraphicBufferAllocator(ulong sAllocList_vaddr){
             sizeStream  << "unknown";
         }
         std::string sizeStr = sizeStream.str();
-        result  << std::setw(12) << std::hex << std::showbase << native_handle_addr << " | "
+        oss  << std::setw(12) << std::hex << std::showbase << native_handle_addr << " | "
                 << std::setw(18) << std::hex << dmabuf << " | " << std::dec
                 << std::setw(12) << sizeStr << " | "
                 << std::setw(4) << rec->width << " (" << std::setw(4) << rec->stride << ") x "
@@ -232,10 +234,10 @@ void SF::dump_GraphicBufferAllocator(ulong sAllocList_vaddr){
                 << requestorName << "\n";
         total += size;
     }
-    result  << "Total allocated by GraphicBufferAllocator (estimate): "
+    oss  << "Total allocated by GraphicBufferAllocator (estimate): "
             << std::fixed << std::setprecision(2)
             << static_cast<double>(total) / 1024.0 << " KB\n";
-    fprintf(fp, "%s \n", result.str().c_str());
+    fprintf(fp, "%s \n", oss.str().c_str());
 }
 
 // GraphicBufferAllocator::sInstance
@@ -388,16 +390,13 @@ bool SF::init_env(){
     return true;
 }
 
-SF::SF(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){
-    init_command();
-}
+SF::SF(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){}
 
 SF::SF(){
-    init_command();
     swap_ptr = std::make_shared<Swapinfo>();
 }
 
-void SF::init_command(){
+void SF::init_command(void){
     cmd_name = "sfg";
     help_str_list={
         "sfg",                            /* command name */
@@ -428,7 +427,6 @@ void SF::init_command(){
         "     FramebufferSurface                      454(512) x 454(464)      0xffffff804ea87000    RGBA_8888   0x1b00",
         "\n",
     };
-    initialize();
 }
 
 #pragma GCC diagnostic pop

--- a/surfaceflinger/sf.h
+++ b/surfaceflinger/sf.h
@@ -185,7 +185,6 @@ protected:
     struct sf_offset_table g_offset;
 
     bool init_env();
-    void init_command();
     void parser_gralloc4();
     void parser_gralloc5();
     void dump_GraphicBufferAllocator(ulong sAllocList_vaddr);
@@ -197,6 +196,8 @@ protected:
 public:
     SF(std::shared_ptr<Swapinfo> swap);
     SF();
+    void init_offset(void) override;
+    void init_command(void) override;
     void cmd_main(void) override;
     DEFINE_PLUGIN_INSTANCE(SF)
 };

--- a/sysinfo/sys.cpp
+++ b/sysinfo/sys.cpp
@@ -43,7 +43,11 @@ void SysInfo::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-SysInfo::SysInfo(){
+void SysInfo::init_offset(void) {
+    struct_init(socinfo);
+}
+
+void SysInfo::init_command(void) {
     cmd_name = "env";
     help_str_list={
         "env",                            /* command name */
@@ -65,9 +69,9 @@ SysInfo::SysInfo(){
         "    %s> env -s",
         "\n",
     };
-    initialize();
-    struct_init(socinfo);
 }
+
+SysInfo::SysInfo(){}
 
 void SysInfo::print_socinfo(){
     field_init(socinfo,id);
@@ -149,6 +153,7 @@ void SysInfo::print_qsocinfo(){
     field_init(socinfo_params,fmt);
     field_init(socinfo_params,nproduct_id);
     struct_init(socinfo_params);
+    std::ostringstream oss;
     for (const auto& dev_addr : for_each_device_for_bus("platform")) {
         std::string device_name;
         size_t name_addr = read_pointer(dev_addr + field_offset(device,kobj) + field_offset(kobject,name),"device name addr");
@@ -191,16 +196,15 @@ void SysInfo::print_qsocinfo(){
         if (hw_id < hw_platforms.size()){
             hw_name = hw_platforms[hw_id];
         }
-        std::ostringstream oss;
         oss << std::left << std::setw(12) << "Chip Family       : " << family << "\n"
             << std::left << std::setw(12) << "Machine           : " << machine << "\n"
             << std::left << std::setw(12) << "Soc ID            : " << soc_id << "\n"
             << std::left << std::setw(12) << "Serial Number     : " << serial_number << "\n"
             << std::left << std::setw(12) << "HARDWARE          : " << hw_name  << "\n"
             << std::left << std::setw(12) << "Product ID        : " << UINT(param_buf + field_offset(socinfo_params,nproduct_id))  << "\n";
-        fprintf(fp, "%s \n",oss.str().c_str());
         FREEBUF(param_buf);
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 void SysInfo::print_soc_info(){
@@ -293,12 +297,12 @@ void SysInfo::print_command_line(){
             kconfigs[mapKey] = "";
         }
     }
+    std::ostringstream oss;
     for (const auto& pair : kconfigs) {
-        std::ostringstream oss;
         oss << std::left << std::setw(max_len + 1) << pair.first
-            << ": " << pair.second;
-        fprintf(fp, "%s \n",oss.str().c_str());
+            << ": " << pair.second << "\n";
     }
+    fprintf(fp, "%s \n",oss.str().c_str());
 }
 
 #pragma GCC diagnostic pop

--- a/sysinfo/sys.h
+++ b/sysinfo/sys.h
@@ -29,12 +29,8 @@ private:
     std::vector<std::string> hw_platforms;
     std::unordered_map<uint32_t, std::string> soc_ids;
 
-public:
-    SysInfo();
-
     void print_socinfo();
     void print_qsocinfo();
-    void cmd_main(void) override;
     void print_command_line();
     void print_soc_info();
     void print_soc_info5();
@@ -42,6 +38,12 @@ public:
     void read_hw_platforms();
     void read_soc_ids();
     uint32_t socinfo_get_raw_id(void *buf);
+
+public:
+    SysInfo();
+    void init_offset(void) override;
+    void init_command(void) override;
+    void cmd_main(void) override;
     DEFINE_PLUGIN_INSTANCE(SysInfo)
 };
 

--- a/systemd/journal.cpp
+++ b/systemd/journal.cpp
@@ -162,10 +162,9 @@ void Journal::get_journal_vma_list(){
 
 bool Journal::write_vma_to_file(std::vector<std::shared_ptr<vma_struct>> vma_list, FILE* logfile){
     for(const auto& vma_ptr : vma_list){
-        void* vma_data = task_ptr->read_vma_data(vma_ptr);
-        if (vma_data){
-            fwrite(vma_data, vma_ptr->vm_size, 1, logfile);
-            std::free(vma_data);
+        std::vector<char> vma_data = task_ptr->read_vma_data(vma_ptr);
+        if (vma_data.size() > 0){
+            fwrite(vma_data.data(), vma_ptr->vm_size, 1, logfile);
         }
     }
     return true;

--- a/systemd/journal.cpp
+++ b/systemd/journal.cpp
@@ -78,19 +78,20 @@ void Journal::cmd_main(void) {
     }
 }
 
-Journal::Journal(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){
-    init_command();
-}
+Journal::Journal(std::shared_ptr<Swapinfo> swap) : swap_ptr(swap){}
 
 Journal::Journal(){
-    init_command();
     swap_ptr = std::make_shared<Swapinfo>();
 }
 
-void Journal::init_command(){
+void Journal::init_offset(void) {
     field_init(inode,i_dentry);
     field_init(inode,i_sb);
     field_init(dentry,d_u);
+}
+
+
+void Journal::init_command(void){
     cmd_name = "systemd";
     help_str_list={
         "systemd",                            /* command name */
@@ -140,7 +141,6 @@ void Journal::init_command(){
         "     [2025-06-17 19:34:52] msm_voice_source_tracking_get: Error getting Source Tracking Params, err=-22",
         "\n",
     };
-    initialize();
 }
 
 void Journal::get_journal_vma_list(){

--- a/systemd/journal.h
+++ b/systemd/journal.h
@@ -22,8 +22,6 @@
 
 class Journal : public ParserPlugin {
 private:
-    std::unordered_map<std::string, std::vector<std::shared_ptr<vma_struct>>> log_vma_list;
-    std::unordered_map<std::string, ulong> log_inode_list;
     static const int DUMP_LOG = 1 << 1;
     static const int LIST_LOG = 1 << 2;
     static const int SHOW_LOG = 1 << 3;
@@ -32,15 +30,13 @@ private:
     std::shared_ptr<UTask> task_ptr = nullptr;
     std::shared_ptr<Swapinfo> swap_ptr;
     struct task_context *tc_systemd_journal = nullptr;
+    std::unordered_map<std::string, std::vector<std::shared_ptr<vma_struct>>> log_vma_list;
+    std::unordered_map<std::string, ulong> log_inode_list;
+
     void get_journal_vma_list();
     bool write_vma_to_file(std::vector<std::shared_ptr<vma_struct>> vma_list, FILE* logfile);
     void get_journal_inode_list();
     bool write_pagecache_to_file(ulong i_mapping, FILE* logfile);
-
-public:
-    Journal(std::shared_ptr<Swapinfo> swap);
-    Journal();
-    void init_command();
     void dump_journal_log_from_vma();
     void dump_journal_log_from_pagecache();
     void print_journal_log_from_vma();
@@ -48,6 +44,12 @@ public:
     void show_journal_log_from_vma(std::string name);
     void show_journal_log_from_pagecache(std::string name);
     void display_journal_log(char* filepath);
+
+public:
+    Journal(std::shared_ptr<Swapinfo> swap);
+    Journal();
+    void init_offset(void) override;
+    void init_command(void) override;
     void cmd_main(void) override;
     DEFINE_PLUGIN_INSTANCE(Journal)
 };

--- a/task/task_sched.cpp
+++ b/task/task_sched.cpp
@@ -50,12 +50,32 @@ void TaskSched::cmd_main(void) {
         cmd_usage(pc->curcmd, SYNOPSIS);
 }
 
-TaskSched::TaskSched(){
+void TaskSched::init_offset(void) {
+    field_init(task_struct,sched_info);
+    field_init(task_struct,exit_state);
+    field_init(task_struct,prio);
+    field_init(task_struct,__state);
+    field_init(task_struct,state);
+    field_init(task_struct,last_enqueued_ts);
+    field_init(task_struct,last_sleep_ts);
+    field_init(task_struct,wts);
+    field_init(task_struct,android_vendor_data1);
+    field_init(sched_info,last_arrival);
+    field_init(sched_info,last_queued);
+    field_init(sched_info,pcount);
+    field_init(sched_info,run_delay);
+    struct_init(sched_info);
+    struct_init(walt_task_struct);
+    field_init(walt_task_struct,last_enqueued_ts);
+    field_init(walt_task_struct,last_sleep_ts);
+}
+
+void TaskSched::init_command(void) {
     cmd_name = "sched";
     help_str_list={
         "sched",                            /* command name */
         "dump task sched information",        /* short description */
-        "-c \n"
+        "-c <cpu>\n"
             "  This command dumps the task sched info.",
         "\n",
         "EXAMPLES",
@@ -67,8 +87,9 @@ TaskSched::TaskSched(){
         "    oom_reaper           61      3     0.591827        0               1.6563e-05      2          120   IN    0               0               0",
         "\n",
     };
-    initialize();
 }
+
+TaskSched::TaskSched(){}
 
 void TaskSched::print_task_timestamps(int cpu){
     std::vector<std::shared_ptr<schedinfo>> task_list;

--- a/task/task_sched.h
+++ b/task/task_sched.h
@@ -31,9 +31,13 @@ struct schedinfo {
 };
 
 class TaskSched : public ParserPlugin {
+private:
+    void print_task_timestamps(int cpu);
+
 public:
     TaskSched();
-    void print_task_timestamps(int cpu);
+    void init_offset(void) override;
+    void init_command(void) override;
     void cmd_main(void) override;
     DEFINE_PLUGIN_INSTANCE(TaskSched)
 };

--- a/thermal/thermal.h
+++ b/thermal/thermal.h
@@ -41,15 +41,19 @@ struct zone_dev {
 };
 
 class Thermal : public ParserPlugin {
-public:
+private:
     std::vector<std::shared_ptr<zone_dev>> zone_list;
-    Thermal();
 
     void print_zone_device();
     void print_zone_device(std::string dev_name);
     void print_cooling_device();
-    void cmd_main(void) override;
     void parser_thrermal_zone();
+
+public:
+    Thermal();
+    void init_offset(void) override;
+    void init_command(void) override;
+    void cmd_main(void) override;
     DEFINE_PLUGIN_INSTANCE(Thermal)
 };
 

--- a/utils/utask.cpp
+++ b/utils/utask.cpp
@@ -18,9 +18,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpointer-arith"
 
-void UTask::cmd_main(void) {
+void UTask::cmd_main(void) {}
 
-}
+void UTask::init_command(void) {}
 
 UTask::UTask(std::shared_ptr<Swapinfo> swap, int pid): swap_ptr(swap){
     tc = pid_to_context(pid);
@@ -51,7 +51,7 @@ UTask::UTask(std::shared_ptr<Swapinfo> swap, ulong addr): swap_ptr(swap){
     }
 }
 
-void UTask::init_offset() {
+void UTask::init_offset(void) {
     field_init(task_struct, state);
     field_init(task_struct, __state);
     field_init(task_struct, real_parent);

--- a/watchdog/wdt.cpp
+++ b/watchdog/wdt.cpp
@@ -44,37 +44,10 @@ void Watchdog::cmd_main(void) {
 }
 
 Watchdog::Watchdog(){
-    field_init(msm_watchdog_data,base);
-    field_init(msm_watchdog_data,pet_time);
-    field_init(msm_watchdog_data,bark_time);
-    field_init(msm_watchdog_data,bark_irq);
-    field_init(msm_watchdog_data,do_ipi_ping);
-    field_init(msm_watchdog_data,in_panic);
-    field_init(msm_watchdog_data,wakeup_irq_enable);
-    field_init(msm_watchdog_data,irq_ppi);
-    field_init(msm_watchdog_data,last_pet);
-    field_init(msm_watchdog_data,alive_mask);
-    field_init(msm_watchdog_data,wdog_cpu_dd);
-    field_init(msm_watchdog_data,enabled);
-    field_init(msm_watchdog_data,user_pet_enabled);
-    field_init(msm_watchdog_data,watchdog_task);
-    field_init(msm_watchdog_data,pet_timer);
-    field_init(msm_watchdog_data,timer_expired);
-    field_init(msm_watchdog_data,user_pet_complete);
-    field_init(msm_watchdog_data,timer_fired);
-    field_init(msm_watchdog_data,thread_start);
-    field_init(msm_watchdog_data,ping_start);
-    field_init(msm_watchdog_data,ping_end);
-    field_init(msm_watchdog_data,cpu_idle_pc_state);
-    field_init(msm_watchdog_data,freeze_in_progress);
-    field_init(msm_watchdog_data,irq_counts);
-    field_init(msm_watchdog_data,ipi_counts);
-    field_init(msm_watchdog_data,irq_counts_running);
-    field_init(msm_watchdog_data,user_pet_timer);
-    field_init(msm_watchdog_data,watchdog_task);
-    field_init(timer_list,expires);
-    field_init(cdev,dev);
-    struct_init(msm_watchdog_data);
+    do_init_offset = false;
+}
+
+void Watchdog::init_command(void) {
     cmd_name = "wdt";
     help_str_list={
         "wdt",                            /* command name */
@@ -123,10 +96,84 @@ Watchdog::Watchdog(){
         "        ping cpu[3]         : 0~0(0ns)",
         "\n",
     };
-    initialize();
+}
+
+void Watchdog::init_offset(void) {
+    if (!init_flag){
+        field_init(msm_watchdog_data,base);
+        field_init(msm_watchdog_data,pet_time);
+        field_init(msm_watchdog_data,bark_time);
+        field_init(msm_watchdog_data,bark_irq);
+        field_init(msm_watchdog_data,do_ipi_ping);
+        field_init(msm_watchdog_data,in_panic);
+        field_init(msm_watchdog_data,wakeup_irq_enable);
+        field_init(msm_watchdog_data,irq_ppi);
+        field_init(msm_watchdog_data,last_pet);
+        field_init(msm_watchdog_data,alive_mask);
+        field_init(msm_watchdog_data,wdog_cpu_dd);
+        field_init(msm_watchdog_data,enabled);
+        field_init(msm_watchdog_data,user_pet_enabled);
+        field_init(msm_watchdog_data,watchdog_task);
+        field_init(msm_watchdog_data,pet_timer);
+        field_init(msm_watchdog_data,timer_expired);
+        field_init(msm_watchdog_data,user_pet_complete);
+        field_init(msm_watchdog_data,timer_fired);
+        field_init(msm_watchdog_data,thread_start);
+        field_init(msm_watchdog_data,ping_start);
+        field_init(msm_watchdog_data,ping_end);
+        field_init(msm_watchdog_data,cpu_idle_pc_state);
+        field_init(msm_watchdog_data,freeze_in_progress);
+        field_init(msm_watchdog_data,irq_counts);
+        field_init(msm_watchdog_data,ipi_counts);
+        field_init(msm_watchdog_data,irq_counts_running);
+        field_init(msm_watchdog_data,user_pet_timer);
+        field_init(msm_watchdog_data,watchdog_task);
+        field_init(timer_list,expires);
+        struct_init(msm_watchdog_data);
+
+        // upstream wdt
+        field_init(watchdog_core_data, cdev);
+        field_init(watchdog_core_data, wdd);
+        field_init(watchdog_core_data, last_keepalive);
+        field_init(watchdog_core_data, open_deadline);
+        field_init(watchdog_core_data, status);
+        field_init(watchdog_core_data, timer);
+        // CONFIG_WATCHDOG_HRTIMER_PRETIMEOUT
+        field_init(watchdog_core_data, pretimeout_timer);
+        field_init(watchdog_core_data, last_hw_keepalive);
+        field_init(watchdog_core_data, last_hw_keepalive);
+        field_init(watchdog_device, pretimeout);
+        field_init(watchdog_device, timeout);
+        field_init(kthread_worker, task);
+        field_init(clock_event_device, next_event);
+        field_init(clock_event_device, cpumask);
+        field_init(tick_device, evtdev);
+        field_init(hrtimer, node);
+        field_init(hrtimer, state);
+        field_init(probe, dev);
+        field_init(probe, data);
+        field_init(timerqueue_node, expires);
+        field_init(task_struct, __state);
+        field_init(task_struct, state);
+        field_init(task_struct, thread_info);
+        field_init(task_struct, stack);
+        field_init(task_struct, on_cpu);
+        field_init(task_struct, cpu);
+        field_init(task_struct, sched_info);
+        field_init(sched_info, last_arrival);
+        field_init(sched_info, last_queued);
+        field_init(thread_info, cpu);
+        struct_init(watchdog_core_data);
+        field_offset(clock_event_device, next_event);
+        field_offset(tick_device, evtdev);
+        field_init(cdev,dev);
+
+        init_flag = true;
+    }
 }
 
 void Watchdog::parser_msm_wdt(){
+    init_offset();
     ulong wdt_addr = read_pointer(csymbol_value("wdog_data"),"wdog_data");
     if (!is_kvaddr(wdt_addr)) {
         fprintf(fp, "wdog_data address is invalid!\n");
@@ -214,6 +261,7 @@ void Watchdog::parser_msm_wdt(){
 }
 
 void Watchdog::parser_upstream_wdt(){
+    init_offset();
     ulong wdt_addr = get_wdt_by_cdev();
     if (!is_kvaddr(wdt_addr)) {
         fprintf(fp, "the upstream wdt do not exist \n");
@@ -251,7 +299,7 @@ void Watchdog::parser_upstream_wdt(){
     ulonglong wdog_task_arrived = read_ulonglong(wdt_task_addr + field_offset(task_struct, sched_info) + field_offset(sched_info, last_arrival), "last_arrival from wdt");
     ulonglong wdog_task_queued = read_ulonglong(wdt_task_addr + field_offset(task_struct, sched_info) + field_offset(sched_info, last_queued), "last_queued from wdt");
     int wdog_task_oncpu = read_int(wdt_task_addr + field_offset(task_struct, on_cpu), "on_cpu from wdt");
-    int wdog_task_cpu = get_task_cpu(wdt_task_addr, get_thread_info_addr(wdt_task_addr));
+    int wdog_task_cpu = get_task_cpu(wdt_task_addr, task_to_thread_info(wdt_task_addr));
     unsigned char pet_timer_state = read_byte(wdt_addr  + field_offset(watchdog_core_data, timer) + field_offset(hrtimer, state), "watchdog_kworker from wdt");
     int bite_time = read_int(watchdog_device + field_offset(watchdog_device, timeout), "timeout from wdt");
     int pretimeout = read_int(watchdog_device + field_offset(watchdog_device, pretimeout), "pretimeout from wdt");
@@ -319,14 +367,6 @@ int Watchdog::get_task_cpu(ulong task_addr, ulong thread_info_addr){
         return read_int(task_addr + field_offset(task_struct, cpu), "cpu from wdt");
     } else {
         return read_int(thread_info_addr + field_offset(thread_info, cpu), "cpu from wdt");
-    }
-}
-
-ulong Watchdog::get_thread_info_addr(ulong task_addr){
-    if(get_config_val("CONFIG_THREAD_INFO_IN_TASK") == "y"){
-        return task_addr + field_offset(task_struct, thread_info);
-    } else {
-        return read_pointer(task_addr + field_offset(task_struct, stack), "stack from wdt");
     }
 }
 

--- a/watchdog/wdt.h
+++ b/watchdog/wdt.h
@@ -19,16 +19,19 @@
 #include "plugin.h"
 
 class Watchdog : public ParserPlugin {
-public:
-    Watchdog();
-
-    void cmd_main(void) override;
+private:
+    bool init_flag = false;
     void parser_msm_wdt();
     void parser_upstream_wdt();
     std::string nstoSec(ulonglong ns);
     ulong get_wdt_by_cdev();
     int get_task_cpu(ulong task_addr, ulong thread_info_addr);
-    ulong get_thread_info_addr(ulong task_addr);
+
+public:
+    Watchdog();
+    void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Watchdog)
 };
 

--- a/workqueue/workqueue.h
+++ b/workqueue/workqueue.h
@@ -111,7 +111,7 @@ struct workqueue_struct{
 };
 
 class Workqueue : public ParserPlugin {
-public:
+private:
     std::vector<std::shared_ptr<workqueue_struct>> workqueue_list;
     std::unordered_map<ulong/* worker ddr address */, std::shared_ptr<worker>> worker_list_map;
     std::unordered_map<ulong/* worker_pool ddr address */, std::shared_ptr<worker_pool>> worker_pool_map;
@@ -124,9 +124,6 @@ public:
     void print_worker();
     void print_pool_by_addr(std::string addr);
     void print_pool();
-
-    template <typename T>
-    std::string parser_flags(uint flags, const std::unordered_map<T, std::string>& flags_array);
     std::vector<std::shared_ptr<work_struct>> parser_work_list(ulong list_head);
     std::shared_ptr<worker> parser_worker(ulong addr,std::shared_ptr<worker_pool> wp_ptr);
     std::vector<std::shared_ptr<worker>> parser_worker_list(ulong list_head_addr,int offset,std::shared_ptr<worker_pool> wp_ptr);
@@ -135,8 +132,14 @@ public:
     std::shared_ptr<workqueue_struct> parser_workqueue_struct(ulong addr);
     void parse_workqueue();
     std::string print_func_name(ulong func_addr);
+    template <typename T>
+    std::string parser_flags(uint flags, const std::unordered_map<T, std::string>& flags_array);
+
+public:
     Workqueue();
     void cmd_main(void) override;
+    void init_offset(void) override;
+    void init_command(void) override;
     DEFINE_PLUGIN_INSTANCE(Workqueue)
 };
 


### PR DESCRIPTION
    1. Refactor plugin initialization flow.
    2. Add two virtual functions to help with automatic setup.
    3. Remove redundant ostringstream usage.
    4. Fix all function declarations in plugins.
    5. Bugfix for memory leak in dts
    6. Remove uread_buffer API