### PR TITLE
Support more regsets and fix the regset type name

### DIFF
--- a/coredump/arm/arm.h
+++ b/coredump/arm/arm.h
@@ -60,8 +60,6 @@ struct arm32_pt_regs{
     unsigned long ORIG_r0;
 };
 
-#define ARM_VFPREGS_SIZE ( 32 * 8 /*fpregs*/ + 4 /*fpscr*/ )
-
 struct elf32_prstatus {
     struct elf_siginfo pr_info;
     short pr_cursig;

--- a/coredump/arm/arm64.h
+++ b/coredump/arm/arm64.h
@@ -70,7 +70,37 @@ struct elf64_prstatus {
     int pr_fpvalid;
 };
 
+struct ptrauth_key {
+    unsigned long lo;
+    unsigned long hi;
+};
+
+struct ptrauth_keys_user {
+    struct ptrauth_key apia;
+    struct ptrauth_key apib;
+    struct ptrauth_key apda;
+    struct ptrauth_key apdb;
+    struct ptrauth_key apga;
+};
+
+struct user_pac_address_keys {
+    // __uint128_t
+    __ull apiakey;
+    __ull apibkey;
+    __ull apdakey;
+    __ull apdbkey;
+};
+
+struct user_pac_generic_keys {
+    // __uint128_t
+    __ull apgakey;
+};
+
 class Arm64 : public Core {
+private:
+    void pac_generic_keys_to_user(user_pac_generic_keys *ukeys, const ptrauth_keys_user *keys);
+    void pac_address_keys_to_user(user_pac_address_keys *ukeys, const ptrauth_keys_user *keys);
+
 public:
     Arm64(std::shared_ptr<Swapinfo> swap);
     ~Arm64();

--- a/coredump/arm/compat.h
+++ b/coredump/arm/compat.h
@@ -28,11 +28,6 @@ typedef int old_time32_t;
 typedef unsigned short __compat_uid_t;
 typedef unsigned short __compat_gid_t;
 
-struct compat_user_fpsimd_state { // VFP_STATE_SIZE
-    __ull/*__uint128_t*/ vregs[16];
-    unsigned int   fpsr;
-};
-
 struct compat_elf_siginfo
 {
     compat_int_t si_signo;

--- a/coredump/core.h
+++ b/coredump/core.h
@@ -54,9 +54,6 @@
 
 #define FAKE_AUXV_PHDR 0x100000
 
-typedef unsigned long long __ull[2];
-
-
 /*
                                         +--------------------------------+
                                         |           ELF Header           |
@@ -100,6 +97,7 @@ typedef unsigned long long __ull[2];
                                         +--------------------------------+
 */
 
+typedef unsigned long long __ull[2];
 
 #ifndef IS_ARM
 struct elf_prpsinfo {
@@ -218,6 +216,11 @@ typedef struct {
     ulong prev;
 } linkmap_t;
 
+struct tls_t {
+    unsigned long tp_value;
+    unsigned long long tpidr2_el0;
+};
+
 class Core : public ParserPlugin {
 private:
     void parser_exec_name(ulong addr);
@@ -270,6 +273,7 @@ protected:
 public:
     static int cmd_flags;
     static std::string symbols_path;
+    static std::string output_path;
     static const int CORE_REPLACE_HEAD = 0x0001;
     static const int CORE_FAKE_LINKMAP = 0x0002;
     std::shared_ptr<UTask> task_ptr;

--- a/coredump/coredump.cpp
+++ b/coredump/coredump.cpp
@@ -29,7 +29,7 @@ void Coredump::cmd_main(void) {
     std::string cppString;
     Core::cmd_flags = 0;
     if (argcnt < 2) cmd_usage(pc->curcmd, SYNOPSIS);
-    while ((c = getopt(argcnt, args, "p:m:l:s:rf")) != EOF) {
+    while ((c = getopt(argcnt, args, "p:m:l:s:d:rf")) != EOF) {
         switch(c) {
             case 'p':
                 cppString.assign(optarg);
@@ -51,6 +51,9 @@ void Coredump::cmd_main(void) {
                 break;
             case 's':
                 Core::symbols_path.assign(optarg);
+                break;
+            case 'd':
+                Core::output_path.assign(optarg);
                 break;
             case 'l':
                 cppString.assign(optarg);


### PR DESCRIPTION
1. NT_ARM_TLS
2. NT_ARM_PACG_KEYS
3. NT_ARM_PACA_KEYS
4. NT_ARM_SYSTEM_CALL
5. The -d parameter can be used to specify the output path.